### PR TITLE
[noticket] handle google expiry time snafu

### DIFF
--- a/app/auth/service_auth.py
+++ b/app/auth/service_auth.py
@@ -39,13 +39,35 @@ def get_isvc_token() -> str:
         return _update_isvc_token()
 
 
+def _google_expiretime_to_datetime(expire_time: str) -> datetime.datetime:
+    """Google's documentation for the generateAccessToken endpoint describes the expireTime field as a timestamp in
+    RFC3339 format, providing the example "2014-10-02T15:01:23.045123456Z" -- i.e. the time all the way to nanoseconds.
+    In practice, the endpoint currently omits the nanoseconds entirely. Google verified this behaviour in a support
+    ticket, unhelpfully adding "At some point in the future we may start supporting fractional times, and would not
+    consider that a breaking change."
+
+    Therefore we need to handle timestamps both with and without nanoseconds. Since this is just a token expiry,
+    dropping the nanoseconds component will mean at worse we refresh the token (one second minus one nanosecond) early.
+
+    https://cloud.google.com/iam/docs/reference/credentials/rest/v1/projects.serviceAccounts/generateAccessToken
+    https://console.cloud.google.com/support/cases/detail/21652153"""
+
+    # if there are nanoseconds, everything left of the dot will be the time (with no Z, so we put it back).
+    # if there aren't nanoseconds, there'll be no dot, so we don't need to reinstate the Z.
+    trunc_time = expire_time.split('.')[0]
+    if trunc_time[-1] != 'Z':
+        trunc_time += 'Z'
+
+    return datetime.datetime.strptime(trunc_time, "%Y-%m-%dT%H:%M:%SZ")
+
+
 def _update_isvc_token() -> str:
     """The app engine SA has token creator on the import service SA"""
     token_response = _get_isvc_token_from_google()
 
     global _cached_isvc_token
     _cached_isvc_token = TokenAndExpiry(token=token_response["accessToken"],
-                                        expiry=datetime.datetime.strptime(token_response["expireTime"], "%Y-%m-%dT%H:%M:%SZ"))
+                                        expiry=_google_expiretime_to_datetime(token_response["expireTime"]))
 
     return _cached_isvc_token.token
 

--- a/app/http/httputils.py
+++ b/app/http/httputils.py
@@ -31,7 +31,8 @@ def httpify_excs(some_func: Callable[..., flask.Response]):
 
 
 def _part_to_regex(part: str) -> str:
-    """Turns <foo> into (?P<foo>[\w\-]+)"""
+    r"""Turns <foo> into (?P<foo>[\w\-]+)
+    (side note: this docstring has to be a raw string with the r-prefix to prevent a DeprecationWarning)"""
     if len(part) == 0:
         return part
     if part[0] == '<' and part[-1] == '>':

--- a/app/tests/test_service_auth.py
+++ b/app/tests/test_service_auth.py
@@ -80,3 +80,11 @@ def test_get_isvc_token():
     with mock.patch("app.auth.service_auth._cached_isvc_token",
                     service_auth.TokenAndExpiry(token="ya29.cached", expiry=datetime.datetime.utcnow() + datetime.timedelta(hours=1))):
         assert service_auth.get_isvc_token() == "ya29.cached"
+
+
+def test_google_expiretime_to_datetime():
+    # test that we truncate nanoseconds correctly
+    assert service_auth._google_expiretime_to_datetime("2014-10-02T15:01:23.045123456Z") == datetime.datetime(2014, 10, 2, 15, 1, 23)
+
+    # test that nothing breaks if there are no nanoseconds
+    assert service_auth._google_expiretime_to_datetime("2014-10-02T15:01:23Z") == datetime.datetime(2014, 10, 2, 15, 1, 23)


### PR DESCRIPTION
Google's [documentation for the generateAccessToken endpoint](https://cloud.google.com/iam/docs/reference/credentials/rest/v1/projects.serviceAccounts/generateAccessToken) describes the expireTime field as a timestamp in RFC3339 format, providing the example "2014-10-02T15:01:23.045123456Z" -- i.e. the time all the way to nanoseconds.

In real life, the endpoint currently omits the nanoseconds entirely. Google verified this behaviour in a [support ticket](https://console.cloud.google.com/support/cases/detail/21652153), unhelpfully adding "At some point in the future we may start supporting fractional times, and would not consider that a breaking change."

Therefore we need to handle timestamps both with and without nanoseconds. Since this is just a token expiry, dropping the nanoseconds component will mean at worse we refresh the token (one second minus one nanosecond) early.