### PR TITLE
Fix mypy getting upset with sqlalchemy enums

### DIFF
--- a/app/db/model.py
+++ b/app/db/model.py
@@ -9,7 +9,7 @@ from sqlalchemy.ext.declarative import declarative_base
 # Mypy gets confused about whether sqlalchemy enum columns are strings or enums, see here:
 # https://github.com/dropbox/sqlalchemy-stubs/issues/114
 # This is the (gross) workaround. Keep an eye on the issue and get rid of it once it's fixed.
-from typing import TYPE_CHECKING, Type, TypeVar, Any
+from typing import TYPE_CHECKING, Type, TypeVar
 if TYPE_CHECKING:
     from sqlalchemy.sql.type_api import TypeEngine
     T = TypeVar('T')


### PR DESCRIPTION
Matt pointed this out to me and I discovered it's already logged in https://github.com/dropbox/sqlalchemy-stubs/issues/114 (the repo for sqlalchemy's type info).

This is a workaround. I'm subscribed to the thread and once they have a fix we can bump our library version and this can go away.