### PR TITLE
[noticket] gzip responses, plus grab bag of minor fixes

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,10 +2,12 @@ import flask
 import flask_compress
 from app.server import routes, json_response
 
+compress = flask_compress.Compress()
+
 
 def create_app() -> flask.Flask:
     app = flask.Flask(__name__)
     app.response_class = json_response.JsonResponse
     app.register_blueprint(routes.routes)
-    flask_compress.Compress(app)
+    compress.init_app(app)
     return app

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,10 +1,11 @@
 import flask
 import flask_compress
-from app.server import routes
+from app.server import routes, json_response
 
 
 def create_app() -> flask.Flask:
     app = flask.Flask(__name__)
+    app.response_class = json_response.JsonResponse
     app.register_blueprint(routes.routes)
     flask_compress.Compress(app)
     return app

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,8 +1,10 @@
 import flask
+import flask_compress
 from app.server import routes
 
 
 def create_app() -> flask.Flask:
     app = flask.Flask(__name__)
     app.register_blueprint(routes.routes)
+    flask_compress.Compress(app)
     return app

--- a/app/server/json_response.py
+++ b/app/server/json_response.py
@@ -1,0 +1,5 @@
+from flask import Response
+
+
+class JsonResponse(Response):
+    default_mimetype = "application/json"

--- a/app/server/routes.py
+++ b/app/server/routes.py
@@ -13,21 +13,21 @@ routes = flask.Blueprint('import-service', __name__, '/')
 @httpify_excs
 def create_import(ws_ns, ws_name) -> flask.Response:
     """Accept an import request"""
-    return flask.make_response(new_import.handle(flask.request, ws_ns, ws_name))
+    return new_import.handle(flask.request, ws_ns, ws_name)
 
 
 @routes.route('/<ws_ns>/<ws_name>/imports/<import_id>', methods=["GET"])
 @httpify_excs
 def import_status(ws_ns, ws_name, import_id) -> flask.Response:
     """Return the status of an import job"""
-    return flask.make_response(status.handle_get_import_status(flask.request, ws_ns, ws_name, import_id))
+    return status.handle_get_import_status(flask.request, ws_ns, ws_name, import_id)
 
 
 @routes.route('/<ws_ns>/<ws_name>/imports', methods=["GET"])
 @httpify_excs
 def import_status_workspace(ws_ns, ws_name) -> flask.Response:
     """Return the status of import jobs in a workspace"""
-    return flask.make_response(status.handle_list_import_status(flask.request, ws_ns, ws_name))
+    return status.handle_list_import_status(flask.request, ws_ns, ws_name)
 
 
 # This particular URL, though weird, can be secured using GCP magic.

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -15,8 +15,8 @@ from typing import IO
 from unittest import mock
 
 from app import create_app
-from app.auth import service_auth
-from app.db import db, model, DBSession
+from app.auth import service_auth, userinfo
+from app.db import db, model
 
 
 def _test_client() -> flask.testing.FlaskClient:
@@ -97,3 +97,23 @@ def pubsub_fake_env(monkeypatch) -> Iterator[None]:
 def fake_pfb() -> Iterator[IO]:
     with open("app/tests/empty.avro", 'rb') as out:
         yield out
+
+
+@pytest.fixture(scope="function")
+def sam_valid_user(monkeypatch):
+    """Makes us think that the current user is valid in Sam."""
+    monkeypatch.setattr("app.external.sam.validate_user",
+                        mock.MagicMock(return_value=userinfo.UserInfo("123456", "hello@bees.com", True)))
+
+
+@pytest.fixture(scope="function")
+def user_has_ws_access(monkeypatch):
+    """Makes us think that the user has access to the workspace in Rawls."""
+    monkeypatch.setattr("app.auth.user_auth.workspace_uuid_with_auth",
+                        mock.MagicMock(return_value="some-uuid"))
+
+
+@pytest.fixture(scope="function")
+def pubsub_publish(monkeypatch):
+    """Replace the publish to google pub/sub with a no-op one"""
+    monkeypatch.setattr("app.external.pubsub.publish_self", mock.MagicMock())

--- a/app/tests/test_gzip.py
+++ b/app/tests/test_gzip.py
@@ -1,0 +1,14 @@
+import flask.testing
+
+
+def test_gzip(client_with_modifiable_routes: flask.testing.FlaskClient):
+    client = client_with_modifiable_routes
+
+    def gzip_me() -> flask.Response:
+        # default min size for gzip compression is 500B
+        return flask.make_response(flask.jsonify({"foo": "a"*500}))
+
+    client.application.add_url_rule("/gzip_test", view_func=gzip_me, methods=["GET"])
+
+    resp = client.get("/gzip_test", headers = {"Accept-Encoding": "gzip"})
+    assert resp.headers["Content-Encoding"] == "gzip"

--- a/app/tests/test_new_import.py
+++ b/app/tests/test_new_import.py
@@ -40,6 +40,7 @@ def test_golden_path(client):
     dbres = sess.query(Import).filter(Import.id == resp.get_data(as_text=True)).all()
     assert len(dbres) == 1
     assert dbres[0].id == str(resp.get_data(as_text=True))
+    assert resp.headers["Content-Type"] == "application/json"
 
 
 @pytest.mark.usefixtures(sam_valid_user, user_has_ws_access)

--- a/app/tests/test_new_import.py
+++ b/app/tests/test_new_import.py
@@ -6,7 +6,6 @@ from app.tests import testutils
 from app import new_import, translate
 from app.util import exceptions
 from app.db import db
-from app.auth import userinfo
 from app.db.model import *
 
 
@@ -17,20 +16,8 @@ def test_schema_valid():
 good_json = {"path": f"https://{translate.VALID_NETLOCS[0]}/some/path", "filetype": "pfb"}
 good_headers = {"Authorization": "Bearer ya29.blahblah"}
 
-sam_valid_user = testutils.fxpatch(
-    "app.external.sam.validate_user",
-    return_value=userinfo.UserInfo("123456", "hello@bees.com", True))
 
-user_has_ws_access = testutils.fxpatch(
-    "app.auth.user_auth.workspace_uuid_with_auth",
-    return_value="some-uuid")
-
-# replace the publish to google pub/sub with a no-op one
-pubsub_publish = testutils.fxpatch(
-    "app.external.pubsub.publish_self")
-
-
-@pytest.mark.usefixtures(sam_valid_user, user_has_ws_access, pubsub_publish, "pubsub_fake_env")
+@pytest.mark.usefixtures("sam_valid_user", "user_has_ws_access", "pubsub_publish", "pubsub_fake_env")
 def test_golden_path(client):
     resp = client.post('/namespace/name/imports', json=good_json, headers=good_headers)
     assert resp.status_code == 201
@@ -43,25 +30,25 @@ def test_golden_path(client):
     assert resp.headers["Content-Type"] == "application/json"
 
 
-@pytest.mark.usefixtures(sam_valid_user, user_has_ws_access)
+@pytest.mark.usefixtures("sam_valid_user", "user_has_ws_access")
 def test_wrong_path(client: flask.testing.FlaskClient):
     resp = client.post('/imports')
     assert resp.status_code == 405
 
 
-@pytest.mark.usefixtures(sam_valid_user, user_has_ws_access)
+@pytest.mark.usefixtures("sam_valid_user", "user_has_ws_access")
 def test_missing_json(client: flask.testing.FlaskClient):
     resp = client.post('/namespace/name/imports', headers=good_headers)
     assert resp.status_code == 400
 
 
-@pytest.mark.usefixtures(sam_valid_user, user_has_ws_access)
+@pytest.mark.usefixtures("sam_valid_user", "user_has_ws_access")
 def test_not_json(client):
     resp = client.post('/namespace/name/imports', data="not a json object", headers=good_headers)
     assert resp.status_code == 400
 
 
-@pytest.mark.usefixtures(sam_valid_user, user_has_ws_access)
+@pytest.mark.usefixtures("sam_valid_user", "user_has_ws_access")
 def test_bad_json(client):
     resp = client.post('/namespace/name/imports', json={"bees":"buzz"}, headers=good_headers)
     assert resp.status_code == 400
@@ -82,7 +69,7 @@ def test_user_not_found(client):
 
 
 @pytest.mark.usefixtures(
-    sam_valid_user,
+    "sam_valid_user",
     testutils.fxpatch(
         "app.auth.user_auth.workspace_uuid_with_auth",
         side_effect = exceptions.ISvcException("what workspace?", 404)))
@@ -92,7 +79,7 @@ def test_user_cant_see_workspace(client):
 
 
 @pytest.mark.usefixtures(
-    sam_valid_user,
+    "sam_valid_user",
     testutils.fxpatch(
         "app.auth.user_auth.workspace_uuid_with_auth",
         side_effect = exceptions.ISvcException("you can't write to this", 403)))

--- a/app/tests/test_path_validation.py
+++ b/app/tests/test_path_validation.py
@@ -9,26 +9,15 @@ from app.db.model import *
 
 good_headers = {"Authorization": "Bearer ya29.blahblah"}
 
-sam_valid_user = testutils.fxpatch(
-    "app.external.sam.validate_user",
-    return_value=userinfo.UserInfo("123456", "hello@bees.com", True))
-
-user_has_ws_access = testutils.fxpatch(
-    "app.auth.user_auth.workspace_uuid_with_auth",
-    return_value="some-uuid")
-
-# replace the publish to google pub/sub with a no-op one
-pubsub_publish = testutils.fxpatch(
-    "app.external.pubsub.publish_self")
 
 def assert_response_code_and_logs(resp, caplog, import_url):
     assert resp.status_code == 400
-    # if the sam_valid_user fixture changes, this assertion will also need to change
+    # if the "sam_valid_user" fixture changes, this assertion will also need to change
     auditlog = filter(lambda rec: rec.message == f"User 123456 hello@bees.com attempted to import from path {import_url}", caplog.records)
     assert list(auditlog), "Expected audit log message to exist if user specified illegal domain; did not find such message in log."
 
 @pytest.mark.parametrize("netloc", translate.VALID_NETLOCS)
-@pytest.mark.usefixtures(sam_valid_user, user_has_ws_access, pubsub_publish, "pubsub_fake_env")
+@pytest.mark.usefixtures("sam_valid_user", "user_has_ws_access", "pubsub_publish", "pubsub_fake_env")
 def test_legal_netlocs_simple(client, netloc):
     payload = {"path": f"https://{netloc}/some/valid/path", "filetype": "pfb"}
     resp = client.post('/namespace/name/imports', json=payload, headers=good_headers)
@@ -36,54 +25,54 @@ def test_legal_netlocs_simple(client, netloc):
     # NB we don't test anything deeper than the 201 response; other tests check to see if the
     # db is updated, etc.
 
-@pytest.mark.usefixtures(sam_valid_user, user_has_ws_access, pubsub_publish, "pubsub_fake_env")
+@pytest.mark.usefixtures("sam_valid_user", "user_has_ws_access", "pubsub_publish", "pubsub_fake_env")
 def test_illegal_netloc_simple(client: flask.testing.FlaskClient, caplog):
     payload = {"path": f"https://haxxor.evil.bad/some/valid/path", "filetype": "pfb"}
     resp = client.post('/namespace/name/imports', json=payload, headers=good_headers)
     assert_response_code_and_logs(resp, caplog, payload["path"])
 
-@pytest.mark.usefixtures(sam_valid_user, user_has_ws_access, pubsub_publish, "pubsub_fake_env")
+@pytest.mark.usefixtures("sam_valid_user", "user_has_ws_access", "pubsub_publish", "pubsub_fake_env")
 def test_unparsable_path(client: flask.testing.FlaskClient, caplog):
     payload = {"path": f"https://[:-999/~~~~~~~~~~~", "filetype": "pfb"}
     resp = client.post('/namespace/name/imports', json=payload, headers=good_headers)
     assert_response_code_and_logs(resp, caplog, payload["path"])
 
 @pytest.mark.parametrize("netloc", translate.VALID_NETLOCS)
-@pytest.mark.usefixtures(sam_valid_user, user_has_ws_access, pubsub_publish, "pubsub_fake_env")
+@pytest.mark.usefixtures("sam_valid_user", "user_has_ws_access", "pubsub_publish", "pubsub_fake_env")
 def test_subdomain_of_legal_netlocs(client, netloc, caplog):
     payload = {"path": f"https://hijacked.{netloc}/some/valid/path", "filetype": "pfb"}
     resp = client.post('/namespace/name/imports', json=payload, headers=good_headers)
     assert_response_code_and_logs(resp, caplog, payload["path"])
 
 @pytest.mark.parametrize("netloc", translate.VALID_NETLOCS)
-@pytest.mark.usefixtures(sam_valid_user, user_has_ws_access, pubsub_publish, "pubsub_fake_env")
+@pytest.mark.usefixtures("sam_valid_user", "user_has_ws_access", "pubsub_publish", "pubsub_fake_env")
 def test_legal_netloc_as_subdomain_of_bad_tld(client, netloc, caplog):
     payload = {"path": f"https://{netloc}.evil/some/valid/path", "filetype": "pfb"}
     resp = client.post('/namespace/name/imports', json=payload, headers=good_headers)
     assert_response_code_and_logs(resp, caplog, payload["path"])
 
 @pytest.mark.parametrize("netloc", translate.VALID_NETLOCS)
-@pytest.mark.usefixtures(sam_valid_user, user_has_ws_access, pubsub_publish, "pubsub_fake_env")
+@pytest.mark.usefixtures("sam_valid_user", "user_has_ws_access", "pubsub_publish", "pubsub_fake_env")
 def test_legal_netloc_in_fragment(client, netloc, caplog):
     payload = {"path": f"https://evil.bad/some/valid/path#{netloc}", "filetype": "pfb"}
     resp = client.post('/namespace/name/imports', json=payload, headers=good_headers)
     assert_response_code_and_logs(resp, caplog, payload["path"])
 
 @pytest.mark.parametrize("netloc", translate.VALID_NETLOCS)
-@pytest.mark.usefixtures(sam_valid_user, user_has_ws_access, pubsub_publish, "pubsub_fake_env")
+@pytest.mark.usefixtures("sam_valid_user", "user_has_ws_access", "pubsub_publish", "pubsub_fake_env")
 def test_legal_netloc_in_query(client, netloc, caplog):
     payload = {"path": f"https://evil.bad/some/valid/path?q={netloc}", "filetype": "pfb"}
     resp = client.post('/namespace/name/imports', json=payload, headers=good_headers)
     assert_response_code_and_logs(resp, caplog, payload["path"])
 
 @pytest.mark.parametrize("netloc", translate.VALID_NETLOCS)
-@pytest.mark.usefixtures(sam_valid_user, user_has_ws_access, pubsub_publish, "pubsub_fake_env")
+@pytest.mark.usefixtures("sam_valid_user", "user_has_ws_access", "pubsub_publish", "pubsub_fake_env")
 def test_legal_netloc_in_path(client, netloc, caplog):
     payload = {"path": f"https://evil.bad/hide/{netloc}/in/path", "filetype": "pfb"}
     resp = client.post('/namespace/name/imports', json=payload, headers=good_headers)
     assert_response_code_and_logs(resp, caplog, payload["path"])
 
-@pytest.mark.usefixtures(sam_valid_user, user_has_ws_access, pubsub_publish, "pubsub_fake_env")
+@pytest.mark.usefixtures("sam_valid_user", "user_has_ws_access", "pubsub_publish", "pubsub_fake_env")
 def test_audit_logging(client: flask.testing.FlaskClient, caplog):
     payload = {"path": "https://illegal.domains/should/be/logged", "filetype": "pfb"}
     resp = client.post('/namespace/name/imports', json=payload, headers=good_headers)

--- a/app/tests/test_status.py
+++ b/app/tests/test_status.py
@@ -9,20 +9,8 @@ from app.tests import testutils
 good_json = {"path": f"https://{translate.VALID_NETLOCS[0]}/some/path", "filetype": "pfb"}
 good_headers = {"Authorization": "Bearer ya29.blahblah"}
 
-sam_valid_user = testutils.fxpatch(
-    "app.external.sam.validate_user",
-    return_value=userinfo.UserInfo("123456", "hello@bees.com", True))
 
-user_has_ws_access = testutils.fxpatch(
-    "app.auth.user_auth.workspace_uuid_with_auth",
-    return_value="some-uuid")
-
-# replace the publish to google pub/sub with a no-op one
-pubsub_publish = testutils.fxpatch(
-    "app.external.pubsub.publish_self")
-
-
-@pytest.mark.usefixtures(sam_valid_user, user_has_ws_access, pubsub_publish, "pubsub_fake_env")
+@pytest.mark.usefixtures("sam_valid_user", "user_has_ws_access", "pubsub_publish", "pubsub_fake_env")
 def test_get_import_status(client):
     new_import_resp = client.post('/namespace/name/imports', json=good_json, headers=good_headers)
     assert new_import_resp.status_code == 201
@@ -33,7 +21,7 @@ def test_get_import_status(client):
     assert resp.get_json(force=True) == {'id': import_id, 'status': ImportStatus.Pending.name}
 
 
-@pytest.mark.usefixtures(sam_valid_user, user_has_ws_access, pubsub_publish, "pubsub_fake_env")
+@pytest.mark.usefixtures("sam_valid_user", "user_has_ws_access", "pubsub_publish", "pubsub_fake_env")
 def test_get_import_status_404(client):
     fake_id = "fake_id"
     resp = client.get('/namespace/name/imports/{}'.format(fake_id), headers=good_headers)
@@ -41,7 +29,7 @@ def test_get_import_status_404(client):
     assert fake_id in resp.get_data(as_text=True)
 
 
-@pytest.mark.usefixtures(sam_valid_user, user_has_ws_access, pubsub_publish, "pubsub_fake_env")
+@pytest.mark.usefixtures("sam_valid_user", "user_has_ws_access", "pubsub_publish", "pubsub_fake_env")
 def test_get_all_import_status(client):
     import_id = client.post('/namespace/name/imports', json=good_json, headers=good_headers).get_data(as_text=True)
 
@@ -50,7 +38,7 @@ def test_get_all_import_status(client):
     assert resp.get_json(force=True) == [{"id": import_id, "status": ImportStatus.Pending.name}]
 
 
-@pytest.mark.usefixtures(sam_valid_user, user_has_ws_access, pubsub_publish, "pubsub_fake_env")
+@pytest.mark.usefixtures("sam_valid_user", "user_has_ws_access", "pubsub_publish", "pubsub_fake_env")
 def test_get_all_running_when_none(client):
     # poke in one import that's in the Done state
     with db.session_ctx() as sess:
@@ -66,7 +54,7 @@ def test_get_all_running_when_none(client):
     assert resp.get_json(force=True) == []
 
 
-@pytest.mark.usefixtures(sam_valid_user, user_has_ws_access, pubsub_publish, "pubsub_fake_env")
+@pytest.mark.usefixtures("sam_valid_user", "user_has_ws_access", "pubsub_publish", "pubsub_fake_env")
 def test_get_all_running_with_one(client):
     import_id = client.post('/namespace/name/imports', json=good_json, headers=good_headers).get_data(as_text=True)
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -31,3 +31,6 @@ ignore_missing_imports = True
 
 [mypy-psutil]
 ignore_missing_imports = True
+
+[mypy-flask_compress]
+ignore_missing_imports = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ requests==2.22.0
 setuptools==42.0.2
 wheel==0.33.6
 Flask==1.1.1
+flask-compress==1.4.0
 Werkzeug==0.16.0
 MarkupSafe==1.1.1
 Jinja2==2.10.3


### PR DESCRIPTION
* gzip responses (> 500B)
* add `Content-Type: application/json` to outgoing responses
* move repeatedly defined fixtures to `conftest.py`
* dedupe repeated calls to `flask.make_response`