### PR TITLE
[AS-216] swagger using flask-restx

### DIFF
--- a/app.yaml.ctmpl
+++ b/app.yaml.ctmpl
@@ -9,6 +9,8 @@ env_variables:
     RAWLS_URL: "{env.rawls_url}"
     SAM_URL: "{env.sam_url}"
 
+    SWAGGER_OAUTH_CLIENT_ID: "{env.oauth_id}"
+
     IMPORT_SVC_SA_EMAIL: "{env.import_svc_sa_email}"
     BATCH_UPSERT_BUCKET: "import-service-batchupsert-{env}"
 

--- a/app.yaml.ctmpl
+++ b/app.yaml.ctmpl
@@ -9,8 +9,6 @@ env_variables:
     RAWLS_URL: "{env.rawls_url}"
     SAM_URL: "{env.sam_url}"
 
-    SWAGGER_OAUTH_CLIENT_ID: "{env.oauth_id}"
-
     IMPORT_SVC_SA_EMAIL: "{env.import_svc_sa_email}"
     BATCH_UPSERT_BUCKET: "import-service-batchupsert-{env}"
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,4 +5,5 @@ from app.server import routes
 def create_app() -> flask.Flask:
     app = flask.Flask(__name__)
     app.register_blueprint(routes.routes)
+    app.config["RESTX_MASK_SWAGGER"] = False  # disable X-Fields header in swagger
     return app

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,9 +1,8 @@
 import flask
-from app.server import routes, json_response
+from app.server import routes
 
 
 def create_app() -> flask.Flask:
     app = flask.Flask(__name__)
-    app.response_class = json_response.JsonResponse
     app.register_blueprint(routes.routes)
     return app

--- a/app/health.py
+++ b/app/health.py
@@ -6,7 +6,7 @@ from app.external import sam, rawls
 
 class HealthResponse:
     def __init__(self, db_health: bool, rawls_health: bool, sam_health: bool):
-        self.ok = all([db_health, rawls_health, sam])
+        self.ok = all([db_health, rawls_health, sam_health])
         self.subsystems = {
             "db": db_health,
             "rawls": rawls_health,

--- a/app/health.py
+++ b/app/health.py
@@ -7,22 +7,24 @@ from app.external import sam, rawls
 class HealthResponse:
     def __init__(self, db_health: bool, rawls_health: bool, sam_health: bool):
         self.ok = all([db_health, rawls_health, sam])
-        self.subsystems = {
-            "db": db_health,
-            "rawls": rawls_health,
-            "sam": sam_health
-        }
+        self.db = db_health
+        self.rawls = rawls_health
+        self.sam = sam_health
 
     @classmethod
-    def get_model(cls) -> model.ModelDefinition:
+    def get_model(cls, api) -> model.ModelDefinition:
         subsystem_fields = {
-            "db": fields.Boolean,
-            "rawls": fields.Boolean,
-            "sam": fields.Boolean
+            "db": fields.Boolean(attribute='db'),
+            "rawls": fields.Boolean(attribute='rawls'),
+            "sam": fields.Boolean(attribute='sam')
         }
         return {
             "ok": fields.Boolean,
-            "subsystems": fields.Nested(subsystem_fields)
+            "subsystems": fields.Nested(api.model('SubsystemModel', {
+                "db": fields.Boolean,
+                "rawls": fields.Boolean,
+                "sam": fields.Boolean
+            }))
         }
 
 

--- a/app/health.py
+++ b/app/health.py
@@ -7,17 +7,14 @@ from app.external import sam, rawls
 class HealthResponse:
     def __init__(self, db_health: bool, rawls_health: bool, sam_health: bool):
         self.ok = all([db_health, rawls_health, sam])
-        self.db = db_health
-        self.rawls = rawls_health
-        self.sam = sam_health
+        self.subsystems = {
+            "db": db_health,
+            "rawls": rawls_health,
+            "sam": sam_health
+        }
 
     @classmethod
     def get_model(cls, api) -> model.ModelDefinition:
-        subsystem_fields = {
-            "db": fields.Boolean(attribute='db'),
-            "rawls": fields.Boolean(attribute='rawls'),
-            "sam": fields.Boolean(attribute='sam')
-        }
         return {
             "ok": fields.Boolean,
             "subsystems": fields.Nested(api.model('SubsystemModel', {

--- a/app/new_import.py
+++ b/app/new_import.py
@@ -1,30 +1,9 @@
 import flask
-import jsonschema
-import logging
 
 from app import translate
-from app.util import exceptions
 from app.db import db, model
 from app.external import sam, pubsub
 from app.auth import user_auth
-
-NEW_IMPORT_SCHEMA = {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "type": "object",
-  "properties": {
-    "path": {
-      "type": "string"
-    },
-    "filetype": {
-      "type": "string",
-      "enum": list(translate.FILETYPE_TRANSLATORS.keys())
-    }
-  },
-  "required": ["path", "filetype"]
-}
-
-
-schema_validator = jsonschema.Draft7Validator(NEW_IMPORT_SCHEMA)
 
 
 def handle(request: flask.Request, ws_ns: str, ws_name: str) -> model.ImportStatusResponse:
@@ -36,12 +15,6 @@ def handle(request: flask.Request, ws_ns: str, ws_name: str) -> model.ImportStat
 
     # make sure the user is allowed to import to this workspace
     workspace_uuid = user_auth.workspace_uuid_with_auth(ws_ns, ws_name, access_token, "write")
-
-    try:  # now validate that the input is correctly shaped
-        schema_validator.validate(request_json)
-    except jsonschema.ValidationError as ve:
-        logging.info("Got malformed JSON.")
-        raise exceptions.BadJsonException(ve.message)
 
     import_url = request_json["path"]
 

--- a/app/new_import.py
+++ b/app/new_import.py
@@ -27,7 +27,7 @@ NEW_IMPORT_SCHEMA = {
 schema_validator = jsonschema.Draft7Validator(NEW_IMPORT_SCHEMA)
 
 
-def handle(request: flask.Request, ws_ns: str, ws_name: str) -> flask.Response:
+def handle(request: flask.Request, ws_ns: str, ws_name: str) -> model.ImportStatusResponse:
     access_token = user_auth.extract_auth_token(request)
     user_info = sam.validate_user(access_token)
 
@@ -62,4 +62,4 @@ def handle(request: flask.Request, ws_ns: str, ws_name: str) -> flask.Response:
 
     pubsub.publish_self({"action": "translate", "import_id": new_import_id})
 
-    return flask.make_response((str(new_import_id), 201))
+    return new_import.to_status_response()

--- a/app/server/json_response.py
+++ b/app/server/json_response.py
@@ -1,5 +1,0 @@
-from flask import Response
-
-
-class JsonResponse(Response):
-    default_mimetype = "application/json"

--- a/app/server/routes.py
+++ b/app/server/routes.py
@@ -58,7 +58,6 @@ pubsub_dispatch: Dict[str, Callable[[Dict[str, str]], Any]] = {
 
 # This particular URL, though weird, can be secured using GCP magic.
 # See https://cloud.google.com/pubsub/docs/push#authenticating_standard_and_urls
-# Note we use @routes.route here to make a route handler but not Swagger.
 @ns.route('/_ah/push-handlers/receive_messages', doc=False)
 class PubSub(Resource):
     @pubsubify_excs

--- a/app/server/routes.py
+++ b/app/server/routes.py
@@ -32,7 +32,7 @@ new_import_model = ns.model("NewImport",
                              {"path": fields.String(required=True),
                               "filetype": fields.String(enum=list(translate.FILETYPE_TRANSLATORS.keys()), required=True)})
 import_status_response_model = ns.model("ImportStatusResponse", model.ImportStatusResponse.get_model())
-health_response_model = ns.model("HealthResponse", health.HealthResponse.get_model())
+health_response_model = ns.model("HealthResponse", health.HealthResponse.get_model(api))
 
 
 @ns.route('/<workspace_project>/<workspace_name>/imports/<import_id>')
@@ -68,6 +68,7 @@ class Imports(Resource):
 @ns.route('/health')
 class Health(Resource):
     @httpify_excs
+    @api.doc(security=None)
     @ns.marshal_with(health_response_model, code=200)
     def get(self):
         """Return whether we and all dependent subsystems are healthy."""

--- a/app/server/routes.py
+++ b/app/server/routes.py
@@ -1,5 +1,5 @@
 import flask
-from flask_restx import Api, Resource
+from flask_restx import Api, Resource, fields
 import json
 import humps
 from typing import Dict, Callable, Any
@@ -10,37 +10,58 @@ import app.auth.service_auth
 from app.server.requestutils import httpify_excs, pubsubify_excs
 
 routes = flask.Blueprint('import-service', __name__, '/')
+
+authorizations = {
+    'Bearer': {
+        "type": "apiKey",
+        "name": "Authorization",
+        "in": "header",
+        "description": "Use your GCP auth token, i.e. `gcloud auth print-access-token`. Required scopes are [openid, email, profile]. Write `Bearer <yourtoken>` in the box."
+    }
+}
+
 api = Api(routes, version='1.0', title='Import Service',
-          description='import service')
+          description='import service',
+          authorizations=authorizations,
+          security=[{"Bearer": "[]"}])
 
 ns = api.namespace('/', description='import handling')
 
 
+new_import_model = ns.model("NewImport",
+                             {"path": fields.String(required=True),
+                              "filetype": fields.String(enum=list(translate.FILETYPE_TRANSLATORS.keys()), required=True)})
 import_status_response_model = ns.model("ImportStatusResponse", model.ImportStatusResponse.get_model())
 
 
-@ns.route('/<ws_ns>/<ws_name>/imports/<import_id>')
+@ns.route('/<workspace_project>/<workspace_name>/imports/<import_id>')
+@ns.param('workspace_project', 'Workspace project')
+@ns.param('workspace_name', 'Workspace name')
+@ns.param('import_id', 'Import id')
 class SpecificImport(Resource):
     @httpify_excs
     @ns.marshal_with(import_status_response_model)
-    def get(self, ws_ns, ws_name, import_id):
+    def get(self, workspace_project, workspace_name, import_id):
         """Return status for this import."""
-        return status.handle_get_import_status(flask.request, ws_ns, ws_name, import_id)
+        return status.handle_get_import_status(flask.request, workspace_project, workspace_name, import_id)
 
 
-@ns.route('/<ws_ns>/<ws_name>/imports')
+@ns.route('/<workspace_project>/<workspace_name>/imports')
+@ns.param('workspace_project', 'Workspace project')
+@ns.param('workspace_name', 'Workspace name')
 class Imports(Resource):
     @httpify_excs
-    @ns.marshal_with(import_status_response_model, 201)
-    def post(self, ws_ns, ws_name):
+    @ns.expect(new_import_model, validate=True)
+    @ns.marshal_with(import_status_response_model, code=201)
+    def post(self, workspace_project, workspace_name):
         """Accept an import request."""
-        return new_import.handle(flask.request, ws_ns, ws_name), 201
+        return new_import.handle(flask.request, workspace_project, workspace_name), 201
 
     @httpify_excs
-    @ns.marshal_with(import_status_response_model, 200)
-    def get(self, ws_ns, ws_name):
+    @ns.marshal_with(import_status_response_model, code=200, as_list=True)
+    def get(self, workspace_project, workspace_name):
         """Return all imports in the workspace."""
-        return status.handle_list_import_status(flask.request, ws_ns, ws_name)
+        return status.handle_list_import_status(flask.request, workspace_project, workspace_name)
 
 
 @routes.route('/health', methods=["GET"])
@@ -61,7 +82,7 @@ pubsub_dispatch: Dict[str, Callable[[Dict[str, str]], Any]] = {
 @ns.route('/_ah/push-handlers/receive_messages', doc=False)
 class PubSub(Resource):
     @pubsubify_excs
-    @ns.marshal_with(import_status_response_model, 200)
+    @ns.marshal_with(import_status_response_model, code=200)
     def post(self) -> flask.Response:
         app.auth.service_auth.verify_pubsub_jwt(flask.request)
 

--- a/app/server/routes.py
+++ b/app/server/routes.py
@@ -32,6 +32,7 @@ new_import_model = ns.model("NewImport",
                              {"path": fields.String(required=True),
                               "filetype": fields.String(enum=list(translate.FILETYPE_TRANSLATORS.keys()), required=True)})
 import_status_response_model = ns.model("ImportStatusResponse", model.ImportStatusResponse.get_model())
+health_response_model = ns.model("HealthResponse", health.HealthResponse.get_model())
 
 
 @ns.route('/<workspace_project>/<workspace_name>/imports/<import_id>')
@@ -64,10 +65,13 @@ class Imports(Resource):
         return status.handle_list_import_status(flask.request, workspace_project, workspace_name)
 
 
-@routes.route('/health', methods=["GET"])
-@httpify_excs
-def health_check() -> flask.Response:
-    return health.handle_health_check()
+@ns.route('/health')
+class Health(Resource):
+    @httpify_excs
+    @ns.marshal_with(health_response_model, code=200)
+    def get(self):
+        """Return whether we and all dependent subsystems are healthy."""
+        return health.handle_health_check(), 200
 
 
 # Dispatcher for pubsub messages.

--- a/app/tests/test_health.py
+++ b/app/tests/test_health.py
@@ -1,0 +1,59 @@
+import flask.testing
+import jsonschema
+import pytest
+from unittest import mock
+
+from app import new_import, translate
+from app.util import exceptions
+from app.db import db
+from app.db.model import *
+
+
+@pytest.fixture(scope="function")
+def sam_ok(monkeypatch):
+    """Makes us think that Sam is fine."""
+    monkeypatch.setattr("app.external.sam.check_health",
+                        mock.MagicMock(return_value=True))
+
+
+@pytest.fixture(scope="function")
+def rawls_ok(monkeypatch):
+    """Makes us think that Rawls is fine."""
+    monkeypatch.setattr("app.external.rawls.check_health",
+                        mock.MagicMock(return_value=True))
+
+
+@pytest.fixture(scope="function")
+def db_ok(monkeypatch):
+    """Makes us think that our db is fine."""
+    monkeypatch.setattr("app.health.check_health",
+                        mock.MagicMock(return_value=True))
+
+
+@pytest.fixture(scope="function")
+def rawls_bad(monkeypatch):
+    """Makes us think that Rawls is dead."""
+    monkeypatch.setattr("app.external.rawls.check_health",
+                        mock.MagicMock(return_value=False))
+
+
+@pytest.mark.usefixtures("sam_ok", "rawls_ok", "db_ok")
+def test_everything_ok(client):
+    resp = client.get('/health')
+    assert resp.status_code == 200
+
+    assert resp.json["ok"]
+    assert resp.json["subsystems"]["rawls"]
+    assert resp.json["subsystems"]["sam"]
+    assert resp.json["subsystems"]["db"]
+
+
+@pytest.mark.usefixtures("sam_ok", "rawls_bad", "db_ok")
+def test_one_subsystem_died(client):
+    resp = client.get('/health')
+    assert resp.status_code == 200
+
+    assert not resp.json["ok"]
+    assert not resp.json["subsystems"]["rawls"]
+    assert resp.json["subsystems"]["sam"]
+    assert resp.json["subsystems"]["db"]

--- a/app/tests/test_new_import.py
+++ b/app/tests/test_new_import.py
@@ -14,7 +14,7 @@ def test_schema_valid():
 
 
 good_json = {"path": f"https://{translate.VALID_NETLOCS[0]}/some/path", "filetype": "pfb"}
-good_headers = {"Authorization": "Bearer ya29.blahblah"}
+good_headers = {"Authorization": "Bearer ya29.blahblah", "Accept": "application/json"}
 
 
 @pytest.mark.usefixtures("sam_valid_user", "user_has_ws_access", "pubsub_publish", "pubsub_fake_env")
@@ -24,9 +24,10 @@ def test_golden_path(client):
 
     # response contains the job ID, check it's actually in the database
     sess = db.get_session()
-    dbres = sess.query(Import).filter(Import.id == resp.get_data(as_text=True)).all()
+    id = resp.json["id"]
+    dbres = sess.query(Import).filter(Import.id == id).all()
     assert len(dbres) == 1
-    assert dbres[0].id == str(resp.get_data(as_text=True))
+    assert dbres[0].id == id
     assert resp.headers["Content-Type"] == "application/json"
 
 

--- a/app/tests/test_new_import.py
+++ b/app/tests/test_new_import.py
@@ -9,10 +9,6 @@ from app.db import db
 from app.db.model import *
 
 
-def test_schema_valid():
-    jsonschema.Draft7Validator.check_schema(new_import.NEW_IMPORT_SCHEMA)
-
-
 good_json = {"path": f"https://{translate.VALID_NETLOCS[0]}/some/path", "filetype": "pfb"}
 good_headers = {"Authorization": "Bearer ya29.blahblah", "Accept": "application/json"}
 

--- a/app/tests/test_status.py
+++ b/app/tests/test_status.py
@@ -15,11 +15,11 @@ good_headers = {"Authorization": "Bearer ya29.blahblah"}
 def test_get_import_status(client):
     new_import_resp = client.post('/namespace/name/imports', json=good_json, headers=good_headers)
     assert new_import_resp.status_code == 201
-    import_id = new_import_resp.get_data(as_text=True)
+    import_id = new_import_resp.json["id"]
 
-    resp = client.get('/namespace/name/imports/{}'.format(import_id), headers=good_headers)
+    resp = client.get(f'/namespace/name/imports/{import_id}', headers=good_headers)
     assert resp.status_code == 200
-    assert resp.get_json(force=True) == {'id': import_id, 'status': ImportStatus.Pending.name}
+    assert resp.json == {'id': import_id, 'status': ImportStatus.Pending.name}
 
 
 @pytest.mark.usefixtures("sam_valid_user", "user_has_ws_access", "pubsub_publish", "pubsub_fake_env")
@@ -32,11 +32,11 @@ def test_get_import_status_404(client):
 
 @pytest.mark.usefixtures("sam_valid_user", "user_has_ws_access", "pubsub_publish", "pubsub_fake_env")
 def test_get_all_import_status(client):
-    import_id = client.post('/namespace/name/imports', json=good_json, headers=good_headers).get_data(as_text=True)
+    import_id = client.post('/namespace/name/imports', json=good_json, headers=good_headers).json["id"]
 
     resp = client.get('/namespace/name/imports', headers=good_headers)
     assert resp.status_code == 200
-    assert resp.get_json(force=True) == [{"id": import_id, "status": ImportStatus.Pending.name}]
+    assert resp.json == [{"id": import_id, "status": ImportStatus.Pending.name}]
 
 
 @pytest.mark.usefixtures("sam_valid_user", "user_has_ws_access", "pubsub_publish", "pubsub_fake_env")
@@ -52,16 +52,16 @@ def test_get_all_running_when_none(client):
 
     resp = client.get('/namespace/name/imports?running_only', headers=good_headers)
     assert resp.status_code == 200
-    assert resp.get_json(force=True) == []
+    assert resp.json == []
 
 
 @pytest.mark.usefixtures("sam_valid_user", "user_has_ws_access", "pubsub_publish", "pubsub_fake_env")
 def test_get_all_running_with_one(client):
-    import_id = client.post('/namespace/name/imports', json=good_json, headers=good_headers).get_data(as_text=True)
+    import_id = client.post('/namespace/name/imports', json=good_json, headers=good_headers).json["id"]
 
     resp = client.get('/namespace/name/imports?running_only', headers=good_headers)
     assert resp.status_code == 200
-    assert resp.get_json(force=True) == [{"id": import_id, "status": ImportStatus.Pending.name}]
+    assert resp.json == [{"id": import_id, "status": ImportStatus.Pending.name}]
 
 
 @pytest.mark.usefixtures("incoming_valid_pubsub")

--- a/mypy.ini
+++ b/mypy.ini
@@ -37,3 +37,6 @@ ignore_missing_imports = True
 
 [mypy-humps]
 ignore_missing_imports = True
+
+[mypy-flask_restx]
+ignore_missing_imports = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ gcsfs==0.6.0
 memunit==0.5.0
 psutil==5.6.7
 pyhumps==1.3.1
+flask-restx==0.1.1


### PR DESCRIPTION
This uses [flask-restx](https://github.com/python-restx/flask-restx) to integrate Swagger. If you want to see it in action, DM me on Slack and I'll send you the link.

The auth is a bit funky. For our Docker-y services, the Apache proxy handles the oauth dance, so we don't have to think about it. Handling OAuth properly would require endpoints in import-service to do the dance ourselves, which isn't necessary in practice as this will hide behind Orchestration and not _need_ to do the dance. Swagger v3 supports auth-in-header but [restx is still only on v2](https://github.com/python-restx/flask-restx/issues/26). Thus we have to do a mildly gross thing and tell Swagger that we're authing using an API key, and expect the user to type the word `Bearer` before their token in the Authorize box. Given this Swagger will only be seen by internal developers this seemed like the right time/effort compromise.