### PR TITLE
[EXPERIMENTAL] swagger using flasgger

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -9,7 +9,17 @@ def create_app() -> flask.Flask:
     app.register_blueprint(routes.routes)
     app.config["SWAGGER"] = {
         'openapi': '3.0.2',
-        'definitions': {"import_request": NEW_IMPORT_SCHEMA}  # TODO: come up with a way of finding all these
+        'definitions': { # TODO: a saner way of consolidating all these
+            "import_request": NEW_IMPORT_SCHEMA,
+            "import_status" : {
+                "type": "object",
+                "properties": {
+                    "id": { "type": "string" },
+                    "status": { "type": "string" }
+                },
+                "required": ["id", "status"]
+            }
+        }
     }
     swagger.init_app(app)
     return app

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,9 +1,15 @@
 import flask
 from app.server import routes, json_response
-
+from app.server.swagger import swagger
+from app.new_import import NEW_IMPORT_SCHEMA
 
 def create_app() -> flask.Flask:
     app = flask.Flask(__name__)
-    app.response_class = json_response.JsonResponse
+    #app.response_class = json_response.JsonResponse
     app.register_blueprint(routes.routes)
+    app.config["SWAGGER"] = {
+        'openapi': '3.0.2',
+        'definitions': {"import_request": NEW_IMPORT_SCHEMA}  # TODO: come up with a way of finding all these
+    }
+    swagger.init_app(app)
     return app

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -3,9 +3,9 @@ from app.server import routes, json_response
 from app.server.swagger import swagger
 from app.new_import import NEW_IMPORT_SCHEMA
 
+
 def create_app() -> flask.Flask:
     app = flask.Flask(__name__)
-    #app.response_class = json_response.JsonResponse
     app.register_blueprint(routes.routes)
     app.config["SWAGGER"] = {
         'openapi': '3.0.2',
@@ -22,4 +22,5 @@ def create_app() -> flask.Flask:
         }
     }
     swagger.init_app(app)
+    app.after_request(json_response.fixup_mimetype)
     return app

--- a/app/new_import.py
+++ b/app/new_import.py
@@ -7,6 +7,9 @@ from app.util import exceptions
 from app.db import db, model
 from app.external import sam, pubsub
 from app.auth import user_auth
+from app.server.swagger import swagger
+
+import flasgger.base
 
 NEW_IMPORT_SCHEMA = {
   "$schema": "http://json-schema.org/draft-07/schema#",
@@ -22,7 +25,6 @@ NEW_IMPORT_SCHEMA = {
   },
   "required": ["path", "filetype"]
 }
-
 
 schema_validator = jsonschema.Draft7Validator(NEW_IMPORT_SCHEMA)
 

--- a/app/server/json_response.py
+++ b/app/server/json_response.py
@@ -1,5 +1,9 @@
-from flask import Response
+import flask
 
 
-class JsonResponse(Response):
-    default_mimetype = "application/json"
+def fixup_mimetype(resp: flask.Response):
+    if flask.request.path.startswith("/apidocs"):
+        resp.mimetype = "text/html"
+    else:
+        resp.mimetype = "application/json"
+    return resp

--- a/app/server/routes.py
+++ b/app/server/routes.py
@@ -37,11 +37,35 @@ def create_import(workspace_namespace, workspace_name) -> flask.Response:
     return new_import.handle(flask.request, workspace_namespace, workspace_name)
 
 
-@routes.route('/<ws_ns>/<ws_name>/imports/<import_id>', methods=["GET"])
+@routes.route('/<workspace_namespace>/<workspace_name>/imports/<import_id>', methods=["GET"])
 @httpify_excs
-def import_status(ws_ns, ws_name, import_id) -> flask.Response:
-    """Return the status of an import job"""
-    return status.handle_get_import_status(flask.request, ws_ns, ws_name, import_id)
+def import_status(workspace_namespace, workspace_name, import_id) -> flask.Response:
+    """Return the status of an import job.
+    ---
+    parameters:
+      - name: workspace_namespace
+        in: path
+        schema:
+          type: string
+        required: true
+      - name: workspace_name
+        in: path
+        schema:
+          type: string
+        required: true
+      - name: import_id
+        in: path
+        schema:
+          type: string
+    responses:
+      200:
+        description: here's the status
+        content:
+          application/json:
+            schema:
+              $ref: '#/definitions/import_status'
+    """
+    return status.handle_get_import_status(flask.request, workspace_namespace, workspace_name, import_id)
 
 
 @routes.route('/<ws_ns>/<ws_name>/imports', methods=["GET"])

--- a/app/server/routes.py
+++ b/app/server/routes.py
@@ -10,11 +10,31 @@ from app.server.requestutils import httpify_excs, pubsubify_excs
 routes = flask.Blueprint('import-service', __name__, '/')
 
 
-@routes.route('/<ws_ns>/<ws_name>/imports', methods=["POST"])
+@routes.route('/<workspace_namespace>/<workspace_name>/imports', methods=["POST"])
 @httpify_excs
-def create_import(ws_ns, ws_name) -> flask.Response:
-    """Accept an import request"""
-    return new_import.handle(flask.request, ws_ns, ws_name)
+def create_import(workspace_namespace, workspace_name) -> flask.Response:
+    """Accept an import request.
+    ---
+    parameters:
+      - name: workspace_namespace
+        in: path
+        schema:
+          type: string
+        required: true
+      - name: workspace_name
+        in: path
+        schema:
+          type: string
+        required: true
+      - name: import_request
+        in: body
+        schema:
+          $ref: '#/definitions/import_request'
+    responses:
+      201:
+        description: it's all good
+    """
+    return new_import.handle(flask.request, workspace_namespace, workspace_name)
 
 
 @routes.route('/<ws_ns>/<ws_name>/imports/<import_id>', methods=["GET"])

--- a/app/server/swagger.py
+++ b/app/server/swagger.py
@@ -1,0 +1,3 @@
+import flasgger
+
+swagger = flasgger.Swagger()

--- a/mypy.ini
+++ b/mypy.ini
@@ -37,3 +37,6 @@ ignore_missing_imports = True
 
 [mypy-humps]
 ignore_missing_imports = True
+
+[mypy-flasgger.*]
+ignore_missing_imports = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ gcsfs==0.6.0
 memunit==0.5.0
 psutil==5.6.7
 pyhumps==1.3.1
+flasgger==0.9.4


### PR DESCRIPTION
This is one of two competing PRs that achieve the same thing. You should read them and compare! The other one is https://github.com/broadinstitute/import-service/pull/21.

This uses [flasgger](https://github.com/flasgger/flasgger) to integrate Swagger. I haven't fleshed out the documentation yet; this is a minimal integration that gets everything working.

As you can see, this is more explicit, and requires less reworking of application code -- at the expense of having to hand-roll docstrings everywhere. My definition of request and response bodies is lazy here, and could use a little more thought, but you get the gist.