### PR TITLE
return error message in import status responses

### DIFF
--- a/app/db/model.py
+++ b/app/db/model.py
@@ -10,7 +10,7 @@ from sqlalchemy_repr import RepresentableBase
 from app.db import DBSession
 
 from flask_restx import fields
-from typing import NamedTuple, Dict
+from typing import Optional, Dict
 
 Base = declarative_base(cls=RepresentableBase)  # sqlalchemy magic base class.
 
@@ -84,15 +84,17 @@ ModelDefinition = Dict[str, Type[fields.Raw]]
 # Note: this should really be a namedtuple but for https://github.com/noirbizarre/flask-restplus/issues/364
 # This is an easy fix in flask-restx if we decide to go this route.
 class ImportStatusResponse:
-    def __init__(self, id: str, status: str):
+    def __init__(self, id: str, status: str, error_message: Optional[str]):
         self.id = id
         self.status = status
+        self.error_message = error_message
 
     @classmethod
     def get_model(cls) -> ModelDefinition:
         return {
             "id": fields.String,
-            "status": fields.String }
+            "status": fields.String,
+            "error_message": fields.String }
 
 
 # This is mypy shenanigans so functions inside the Import class can return an instance of type Import.
@@ -156,4 +158,4 @@ class Import(ImportServiceTable, EqMixin, Base):
         self.status = ImportStatus.Error
 
     def to_status_response(self) -> ImportStatusResponse:
-        return ImportStatusResponse(self.id, self.status.name)
+        return ImportStatusResponse(self.id, self.status.name, self.error_message)

--- a/app/server/routes.py
+++ b/app/server/routes.py
@@ -60,6 +60,8 @@ class Imports(Resource):
 
     @httpify_excs
     @ns.marshal_with(import_status_response_model, code=200, as_list=True)
+    @api.doc(params={'running_only': {'in':'query', 'type': 'boolean', 'default':False,
+       'description': "Return only running imports. Adding the query parameter ?running_only with no assigned value will assume true."}})
     def get(self, workspace_project, workspace_name):
         """Return all imports in the workspace."""
         return status.handle_list_import_status(flask.request, workspace_project, workspace_name)

--- a/app/status.py
+++ b/app/status.py
@@ -30,7 +30,9 @@ def handle_get_import_status(request: flask.Request, ws_ns: str, ws_name: str, i
 
 
 def handle_list_import_status(request: flask.Request, ws_ns: str, ws_name: str) -> List[model.ImportStatusResponse]:
-    running_only = "running_only" in request.args
+    # in the case where someone specifies ?running_only rather than ?running_only=true, assume true
+    # this also means that ?running_only=boom is interpreted as true, but that seems okay to me
+    running_only = request.args.get("running_only", "False").lower() != "false"
 
     access_token = user_auth.extract_auth_token(request)
     sam.validate_user(access_token)

--- a/app/status.py
+++ b/app/status.py
@@ -85,4 +85,4 @@ def external_update_status(msg: Dict[str, str]) -> model.ImportStatusResponse:
         logging.warning(f"Failed to update status for import {import_id}: expected {current_status}, got {imp.status}.")
 
     # This goes back to Pub/Sub, nobody reads it
-    return model.ImportStatusResponse(import_id, new_status.name)
+    return model.ImportStatusResponse(import_id, new_status.name, None)

--- a/app/translate.py
+++ b/app/translate.py
@@ -76,7 +76,7 @@ def handle(msg: Dict[str, str]) -> ImportStatusResponse:
         "upsertFile": dest_file
     })
 
-    return ImportStatusResponse(import_id, ImportStatus.ReadyForUpsert.name)
+    return ImportStatusResponse(import_id, ImportStatus.ReadyForUpsert.name, None)
 
 
 def _stream_translate(source: IO, dest: IO, translator: Translator) -> None:


### PR DESCRIPTION
now responses look like:

```
{
  "id" : "uuid-1234",
  "status" : "Pending",
  "error_message" : null
}
```

or if `status == Error`, then `error_message` will be a string