### PR TITLE
AS-155: rename payloads

### DIFF
--- a/app/db/model.py
+++ b/app/db/model.py
@@ -98,17 +98,29 @@ class ImportStatusResponse:
 
 # For backwards compatibility, new-import requests return a different response payload
 # than get-import-status requests.
-class NewImportResponse:
-    def __init__(self, url: str, jobId: str):
-        self.url = url
-        self.jobId = jobId
+class WorkspaceSpec:
+    def __init__(self, namespace: str, name: str):
+        self.namespace = namespace
+        self.name = name
 
     @classmethod
     def get_model(cls) -> ModelDefinition:
         return {
-            "url": fields.String,
-            "jobId": fields.String }
+            "namespace": fields.String,
+            "name": fields.String }
 
+class NewImportResponse:
+    def __init__(self, url: str, jobId: str, workspace: WorkspaceSpec):
+        self.url = url
+        self.jobId = jobId
+        self.workspace = workspace
+
+    @classmethod
+    def get_model(cls, api) -> ModelDefinition:
+        return {
+            "url": fields.String,
+            "jobId": fields.String,
+            "workspace": fields.Nested(api.model("workspace", WorkspaceSpec.get_model())) }
 
 # This is mypy shenanigans so functions inside the Import class can return an instance of type Import.
 # It's basically a forward declaration of the type.
@@ -174,4 +186,4 @@ class Import(ImportServiceTable, EqMixin, Base):
         return ImportStatusResponse(self.id, self.status.name, self.error_message)
 
     def to_new_import_response(self, url: str, namespace: str, name: str) -> NewImportResponse:
-        return NewImportResponse(url, self.id)
+        return NewImportResponse(url, self.id, WorkspaceSpec(namespace, name))

--- a/app/db/model.py
+++ b/app/db/model.py
@@ -96,6 +96,19 @@ class ImportStatusResponse:
             "status": fields.String,
             "message": fields.String }
 
+# For backwards compatibility, new-import requests return a different response payload
+# than get-import-status requests.
+class NewImportResponse:
+    def __init__(self, url: str, jobId: str):
+        self.url = url
+        self.jobId = jobId
+
+    @classmethod
+    def get_model(cls) -> ModelDefinition:
+        return {
+            "url": fields.String,
+            "jobId": fields.String }
+
 
 # This is mypy shenanigans so functions inside the Import class can return an instance of type Import.
 # It's basically a forward declaration of the type.
@@ -159,3 +172,6 @@ class Import(ImportServiceTable, EqMixin, Base):
 
     def to_status_response(self) -> ImportStatusResponse:
         return ImportStatusResponse(self.id, self.status.name, self.error_message)
+
+    def to_new_import_response(self, url: str, namespace: str, name: str) -> NewImportResponse:
+        return NewImportResponse(url, self.id)

--- a/app/db/model.py
+++ b/app/db/model.py
@@ -96,32 +96,6 @@ class ImportStatusResponse:
             "status": fields.String,
             "message": fields.String }
 
-# For backwards compatibility, new-import requests return a different response payload
-# than get-import-status requests.
-class WorkspaceSpec:
-    def __init__(self, namespace: str, name: str):
-        self.namespace = namespace
-        self.name = name
-
-    @classmethod
-    def get_model(cls) -> ModelDefinition:
-        return {
-            "namespace": fields.String,
-            "name": fields.String }
-
-class NewImportResponse:
-    def __init__(self, url: str, jobId: str, workspace: WorkspaceSpec):
-        self.url = url
-        self.jobId = jobId
-        self.workspace = workspace
-
-    @classmethod
-    def get_model(cls, api) -> ModelDefinition:
-        return {
-            "url": fields.String,
-            "jobId": fields.String,
-            "workspace": fields.Nested(api.model("workspace", WorkspaceSpec.get_model())) }
-
 # This is mypy shenanigans so functions inside the Import class can return an instance of type Import.
 # It's basically a forward declaration of the type.
 ImportT = TypeVar('ImportT', bound='Import')
@@ -184,6 +158,3 @@ class Import(ImportServiceTable, EqMixin, Base):
 
     def to_status_response(self) -> ImportStatusResponse:
         return ImportStatusResponse(self.id, self.status.name, self.error_message)
-
-    def to_new_import_response(self, url: str, namespace: str, name: str) -> NewImportResponse:
-        return NewImportResponse(url, self.id, WorkspaceSpec(namespace, name))

--- a/app/db/model.py
+++ b/app/db/model.py
@@ -84,17 +84,17 @@ ModelDefinition = Dict[str, Type[fields.Raw]]
 # Note: this should really be a namedtuple but for https://github.com/noirbizarre/flask-restplus/issues/364
 # This is an easy fix in flask-restx if we decide to go this route.
 class ImportStatusResponse:
-    def __init__(self, id: str, status: str, error_message: Optional[str]):
-        self.id = id
+    def __init__(self, jobId: str, status: str, message: Optional[str]):
+        self.jobId = jobId
         self.status = status
-        self.error_message = error_message
+        self.message = message
 
     @classmethod
     def get_model(cls) -> ModelDefinition:
         return {
-            "id": fields.String,
+            "jobId": fields.String,
             "status": fields.String,
-            "error_message": fields.String }
+            "message": fields.String }
 
 
 # This is mypy shenanigans so functions inside the Import class can return an instance of type Import.

--- a/app/new_import.py
+++ b/app/new_import.py
@@ -6,7 +6,7 @@ from app.external import sam, pubsub
 from app.auth import user_auth
 
 
-def handle(request: flask.Request, ws_ns: str, ws_name: str) -> model.ImportStatusResponse:
+def handle(request: flask.Request, ws_ns: str, ws_name: str) -> model.NewImportResponse:
     access_token = user_auth.extract_auth_token(request)
     user_info = sam.validate_user(access_token)
 

--- a/app/new_import.py
+++ b/app/new_import.py
@@ -16,6 +16,7 @@ def handle(request: flask.Request, ws_ns: str, ws_name: str) -> model.ImportStat
     # make sure the user is allowed to import to this workspace
     workspace_uuid = user_auth.workspace_uuid_with_auth(ws_ns, ws_name, access_token, "write")
 
+    # TODO: AS-155: change to "url"?
     import_url = request_json["path"]
 
     # and validate the input's path
@@ -35,4 +36,4 @@ def handle(request: flask.Request, ws_ns: str, ws_name: str) -> model.ImportStat
 
     pubsub.publish_self({"action": "translate", "import_id": new_import_id})
 
-    return new_import.to_status_response()
+    return new_import.to_new_import_response(import_url, ws_ns, ws_name)

--- a/app/new_import.py
+++ b/app/new_import.py
@@ -6,7 +6,7 @@ from app.external import sam, pubsub
 from app.auth import user_auth
 
 
-def handle(request: flask.Request, ws_ns: str, ws_name: str) -> model.NewImportResponse:
+def handle(request: flask.Request, ws_ns: str, ws_name: str) -> model.ImportStatusResponse:
     access_token = user_auth.extract_auth_token(request)
     user_info = sam.validate_user(access_token)
 
@@ -36,4 +36,4 @@ def handle(request: flask.Request, ws_ns: str, ws_name: str) -> model.NewImportR
 
     pubsub.publish_self({"action": "translate", "import_id": new_import_id})
 
-    return new_import.to_new_import_response(import_url, ws_ns, ws_name)
+    return new_import.to_status_response()

--- a/app/server/routes.py
+++ b/app/server/routes.py
@@ -32,6 +32,7 @@ new_import_model = ns.model("NewImport",
                              {"path": fields.String(required=True),
                               "filetype": fields.String(enum=list(translate.FILETYPE_TRANSLATORS.keys()), required=True)})
 import_status_response_model = ns.model("ImportStatusResponse", model.ImportStatusResponse.get_model())
+new_import_response_model = ns.model("NewImportResponse", model.NewImportResponse.get_model())
 health_response_model = ns.model("HealthResponse", health.HealthResponse.get_model(api))
 
 
@@ -53,7 +54,7 @@ class SpecificImport(Resource):
 class Imports(Resource):
     @httpify_excs
     @ns.expect(new_import_model, validate=True)
-    @ns.marshal_with(import_status_response_model, code=201)
+    @ns.marshal_with(new_import_response_model, code=201)
     def post(self, workspace_project, workspace_name):
         """Accept an import request."""
         return new_import.handle(flask.request, workspace_project, workspace_name), 201

--- a/app/server/routes.py
+++ b/app/server/routes.py
@@ -42,7 +42,7 @@ health_response_model = ns.model("HealthResponse", health.HealthResponse.get_mod
 @ns.param('import_id', 'Import id')
 class SpecificImport(Resource):
     @httpify_excs
-    @ns.marshal_with(import_status_response_model)
+    @ns.marshal_with(import_status_response_model, skip_none=True)
     def get(self, workspace_project, workspace_name, import_id):
         """Return status for this import."""
         return status.handle_get_import_status(flask.request, workspace_project, workspace_name, import_id)
@@ -60,7 +60,7 @@ class Imports(Resource):
         return new_import.handle(flask.request, workspace_project, workspace_name), 201
 
     @httpify_excs
-    @ns.marshal_with(import_status_response_model, code=200, as_list=True)
+    @ns.marshal_with(import_status_response_model, code=200, as_list=True, skip_none=True)
     @api.doc(params={'running_only': {'in':'query', 'type': 'boolean', 'default':False,
        'description': "Return only running imports. Adding the query parameter ?running_only with no assigned value will assume true."}})
     def get(self, workspace_project, workspace_name):
@@ -83,7 +83,7 @@ class Health(Resource):
 @ns.route('/_ah/push-handlers/receive_messages', doc=False)
 class PubSub(Resource):
     @pubsubify_excs
-    @ns.marshal_with(import_status_response_model, code=200)
+    @ns.marshal_with(import_status_response_model, code=200, skip_none=True)
     def post(self):
         app.auth.service_auth.verify_pubsub_jwt(flask.request)
 

--- a/app/server/routes.py
+++ b/app/server/routes.py
@@ -32,7 +32,6 @@ new_import_model = ns.model("NewImport",
                              {"path": fields.String(required=True),
                               "filetype": fields.String(enum=list(translate.FILETYPE_TRANSLATORS.keys()), required=True)})
 import_status_response_model = ns.model("ImportStatusResponse", model.ImportStatusResponse.get_model())
-new_import_response_model = ns.model("NewImportResponse", model.NewImportResponse.get_model(api))
 health_response_model = ns.model("HealthResponse", health.HealthResponse.get_model(api))
 
 
@@ -54,7 +53,7 @@ class SpecificImport(Resource):
 class Imports(Resource):
     @httpify_excs
     @ns.expect(new_import_model, validate=True)
-    @ns.marshal_with(new_import_response_model, code=201)
+    @ns.marshal_with(import_status_response_model, code=201, skip_none=True)
     def post(self, workspace_project, workspace_name):
         """Accept an import request."""
         return new_import.handle(flask.request, workspace_project, workspace_name), 201

--- a/app/server/routes.py
+++ b/app/server/routes.py
@@ -32,7 +32,7 @@ new_import_model = ns.model("NewImport",
                              {"path": fields.String(required=True),
                               "filetype": fields.String(enum=list(translate.FILETYPE_TRANSLATORS.keys()), required=True)})
 import_status_response_model = ns.model("ImportStatusResponse", model.ImportStatusResponse.get_model())
-new_import_response_model = ns.model("NewImportResponse", model.NewImportResponse.get_model())
+new_import_response_model = ns.model("NewImportResponse", model.NewImportResponse.get_model(api))
 health_response_model = ns.model("HealthResponse", health.HealthResponse.get_model(api))
 
 

--- a/app/tests/test_new_import.py
+++ b/app/tests/test_new_import.py
@@ -25,10 +25,6 @@ def test_golden_path(client):
     assert len(dbres) == 1
     assert dbres[0].id == id
     assert resp.headers["Content-Type"] == "application/json"
-    assert resp.json["workspace"]["namespace"] == "mynamespace"
-    assert resp.json["workspace"]["name"] == "myname"
-    assert resp.json["url"] == good_json["path"]
-
 
 @pytest.mark.usefixtures("sam_valid_user", "user_has_ws_access")
 def test_wrong_path(client: flask.testing.FlaskClient):

--- a/app/tests/test_new_import.py
+++ b/app/tests/test_new_import.py
@@ -15,7 +15,7 @@ good_headers = {"Authorization": "Bearer ya29.blahblah", "Accept": "application/
 
 @pytest.mark.usefixtures("sam_valid_user", "user_has_ws_access", "pubsub_publish", "pubsub_fake_env")
 def test_golden_path(client):
-    resp = client.post('/namespace/name/imports', json=good_json, headers=good_headers)
+    resp = client.post('/mynamespace/myname/imports', json=good_json, headers=good_headers)
     assert resp.status_code == 201
 
     # response contains the job ID, check it's actually in the database
@@ -25,6 +25,9 @@ def test_golden_path(client):
     assert len(dbres) == 1
     assert dbres[0].id == id
     assert resp.headers["Content-Type"] == "application/json"
+    assert resp.json["workspace"]["namespace"] == "mynamespace"
+    assert resp.json["workspace"]["name"] == "myname"
+    assert resp.json["url"] == good_json["path"]
 
 
 @pytest.mark.usefixtures("sam_valid_user", "user_has_ws_access")

--- a/app/tests/test_new_import.py
+++ b/app/tests/test_new_import.py
@@ -20,7 +20,7 @@ def test_golden_path(client):
 
     # response contains the job ID, check it's actually in the database
     sess = db.get_session()
-    id = resp.json["id"]
+    id = resp.json["jobId"]
     dbres = sess.query(Import).filter(Import.id == id).all()
     assert len(dbres) == 1
     assert dbres[0].id == id

--- a/app/tests/test_status.py
+++ b/app/tests/test_status.py
@@ -19,7 +19,7 @@ def test_get_import_status(client):
 
     resp = client.get(f'/namespace/name/imports/{import_id}', headers=good_headers)
     assert resp.status_code == 200
-    assert resp.json == {'jobId': import_id, 'status': ImportStatus.Pending.name, 'message': None}
+    assert resp.json == {'jobId': import_id, 'status': ImportStatus.Pending.name}
 
 
 @pytest.mark.usefixtures("sam_valid_user", "user_has_ws_access", "pubsub_publish", "pubsub_fake_env")
@@ -64,7 +64,7 @@ def test_get_all_running_with_one(client):
 
     resp = client.get('/namespace/name/imports?running_only', headers=good_headers)
     assert resp.status_code == 200
-    assert resp.json == [{"jobId": import_id, "status": ImportStatus.Pending.name, "message": None}]
+    assert resp.json == [{"jobId": import_id, "status": ImportStatus.Pending.name}]
 
 
 @pytest.mark.usefixtures("incoming_valid_pubsub")

--- a/app/tests/test_status.py
+++ b/app/tests/test_status.py
@@ -15,11 +15,11 @@ good_headers = {"Authorization": "Bearer ya29.blahblah"}
 def test_get_import_status(client):
     new_import_resp = client.post('/namespace/name/imports', json=good_json, headers=good_headers)
     assert new_import_resp.status_code == 201
-    import_id = new_import_resp.json["id"]
+    import_id = new_import_resp.json["jobId"]
 
     resp = client.get(f'/namespace/name/imports/{import_id}', headers=good_headers)
     assert resp.status_code == 200
-    assert resp.json == {'id': import_id, 'status': ImportStatus.Pending.name, 'error_message': None}
+    assert resp.json == {'jobId': import_id, 'status': ImportStatus.Pending.name, 'message': None}
 
 
 @pytest.mark.usefixtures("sam_valid_user", "user_has_ws_access", "pubsub_publish", "pubsub_fake_env")
@@ -39,7 +39,7 @@ def test_get_all_import_status(fake_import, client):
 
     resp = client.get('/aa/aa/imports', headers=good_headers)
     assert resp.status_code == 200
-    assert resp.json == [{"id": fake_import.id, "status": ImportStatus.Error.name, 'error_message': "broke"}]
+    assert resp.json == [{"jobId": fake_import.id, "status": ImportStatus.Error.name, 'message': "broke"}]
 
 
 @pytest.mark.usefixtures("sam_valid_user", "user_has_ws_access", "pubsub_publish", "pubsub_fake_env")
@@ -60,11 +60,11 @@ def test_get_all_running_when_none(client):
 
 @pytest.mark.usefixtures("sam_valid_user", "user_has_ws_access", "pubsub_publish", "pubsub_fake_env")
 def test_get_all_running_with_one(client):
-    import_id = client.post('/namespace/name/imports', json=good_json, headers=good_headers).json["id"]
+    import_id = client.post('/namespace/name/imports', json=good_json, headers=good_headers).json["jobId"]
 
     resp = client.get('/namespace/name/imports?running_only', headers=good_headers)
     assert resp.status_code == 200
-    assert resp.json == [{"id": import_id, "status": ImportStatus.Pending.name, "error_message": None}]
+    assert resp.json == [{"jobId": import_id, "status": ImportStatus.Pending.name, "message": None}]
 
 
 @pytest.mark.usefixtures("incoming_valid_pubsub")


### PR DESCRIPTION
The get-import-status *response* payload now matches the payload currently returned by orch. This will allow orch to be purely passthrough for this endpoint, no additional logic; and should hopefully ease any end-to-end debugging.

We can't/shouldn't change the orch payloads, for backwards compatibility. Changing payloads of our public API would break the UIs.

I have *not* changed the create-import api,  since that would cause internal inconsistency inside import service.  For that api specifically, I'll munge both the request and response payloads inside orch.