### PR TITLE
add prod export host for BDC [no ticket; risk: low]

### DIFF
--- a/app/translate.py
+++ b/app/translate.py
@@ -23,7 +23,7 @@ import requests.exceptions
 
 FILETYPE_TRANSLATORS = {"pfb": PFBToRawls}
 
-VALID_NETLOCS = ["gen3-pfb-export.s3.amazonaws.com", "staging-pfb-export.s3.amazonaws.com", "storage.googleapis.com"]
+VALID_NETLOCS = ["gen3-datastage-io-pfb-export.s3.amazonaws.com", "gen3-pfb-export.s3.amazonaws.com", "staging-pfb-export.s3.amazonaws.com", "storage.googleapis.com"]
 
 
 def handle(msg: Dict[str, str]) -> ImportStatusResponse:


### PR DESCRIPTION
whitelists the `gen3-datastage-io-pfb-export.s3.amazonaws.com` location that BDC is currently using

![Screenshot (11)](https://user-images.githubusercontent.com/6041577/81750166-fd036300-947a-11ea-8965-2b775fb2e631.png)
