### PR TITLE
AS-392: upgrade pypfb version to inherit encoding/decoding fixes [risk: low]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ google-cloud-iam==0.2.1
 google-api-python-client==1.7.11
 google-cloud-pubsub==1.1.0
 oauth2client==4.1.3
-pypfb==0.4.2
+pypfb==0.4.3
 gcsfs==0.6.0
 memunit==0.5.0
 psutil==5.6.7


### PR DESCRIPTION
We've been seeing an error attempting to import certain PFBs, such as the "minimal example" file noted in https://github.com/uc-cdis/pypfb/pull/35.

UChicago (owners of pypfb) said:

> We found the error in pypfb to be an issue with other dependencies. We have resolved it and released a new version. You should be good to update pypfb and work on the minimal PFB.
> 
> pip install pypfb --upgrade
> https://github.com/uc-cdis/pypfb/releases/tag/0.4.3

So ... let's upgrade to pypfb 0.4.3