### PR TITLE
AS-447, AS-364: validate netlocs by suffix and improve translation error messaging

### DIFF
--- a/app/tests/test_path_validation.py
+++ b/app/tests/test_path_validation.py
@@ -40,9 +40,9 @@ def test_unparsable_path(client: flask.testing.FlaskClient, caplog):
 @pytest.mark.parametrize("netloc", translate.VALID_NETLOCS)
 @pytest.mark.usefixtures("sam_valid_user", "user_has_ws_access", "pubsub_publish", "pubsub_fake_env")
 def test_subdomain_of_legal_netlocs(client, netloc, caplog):
-    payload = {"path": f"https://hijacked.{netloc}/some/valid/path", "filetype": "pfb"}
+    payload = {"path": f"https://subdomain.{netloc}/some/valid/path", "filetype": "pfb"}
     resp = client.post('/namespace/name/imports', json=payload, headers=good_headers)
-    assert_response_code_and_logs(resp, caplog, payload["path"])
+    assert resp.status_code == 201
 
 @pytest.mark.parametrize("netloc", translate.VALID_NETLOCS)
 @pytest.mark.usefixtures("sam_valid_user", "user_has_ws_access", "pubsub_publish", "pubsub_fake_env")

--- a/app/util/exceptions.py
+++ b/app/util/exceptions.py
@@ -59,9 +59,9 @@ class FileTranslationException(ISvcException):
         eid = uuid.uuid4()
         tb = exc.__traceback__
 
-        user_msg = f"Error translating file: {imprt.import_url}\n" + \
-                                       f"{str(exc)}\n" + \
-                                       f"eid: {str(eid)}"
+        user_msg = f"Error translating file (eid: {str(eid)}). This file is likely corrupt or contains illegal syntax. " + \
+                   f"Please check your file for validity before trying again. Underlying error message: " + \
+                   f"{str(exc)} for file {imprt.import_url}"
 
         audit_logs = [AuditLog(f"Error translating import id: {imprt.id} \n" +
                                f"file: {imprt.import_url} \n" +


### PR DESCRIPTION
Two changes in this PR:

* for AS-447: validate the locations from which we will read PFBs by checking if they end with one of the known-good locations in our allowlist, instead of looking for an exact match. This means we can allow all subdomains of s3.amazonaws.com without having to list each one.
* for AS-364: if we encounter an error parsing a PFB, make the error message to the end user much clearer that they may need to take action.