### PR TITLE
AS-456: error handling and debugging [risk: low]

### DIFF
--- a/app.yaml.ctmpl
+++ b/app.yaml.ctmpl
@@ -28,8 +28,12 @@ basic_scaling:
 #
 # default instance_class for automatic_scaling is F1: 256MB / 600MHz
 # default instance_class for basic_scaling is B2: 512MB / 1.2GHz
+# other instance_class options:
+#   B4: 1024MB / 2.4GHz
+#   B4_1G: 2048MB / 2.4GHz
+#   B8: 2048MB / 4.8GHz
 #
-# instance_class: B2
+instance_class: B4
 
 # in the ctmpl below, the token "vault" means secret/dsde/firecloud/<env>/import-service/
 # vault/foo.bar means vault read secret/dsde/firecloud/<env>/import-service/foo and look for the "bar" key

--- a/app/external/pubsub.py
+++ b/app/external/pubsub.py
@@ -8,10 +8,11 @@ _subscriber_client: Optional[pubsub_v1.SubscriberClient] = None
 
 
 def _get_publisher_client() -> pubsub_v1.PublisherClient:
-    global _publisher_client
-    if _publisher_client is None:
-        _publisher_client = pubsub_v1.PublisherClient(credentials=service_auth.get_isvc_credential())
-    return _publisher_client
+    # global _publisher_client
+    # if _publisher_client is None:
+    #     _publisher_client = pubsub_v1.PublisherClient(credentials=service_auth.get_isvc_credential())
+    # return _publisher_client
+    return pubsub_v1.PublisherClient(credentials=service_auth.get_isvc_credential())
 
 
 def create_topic_and_sub() -> None:
@@ -44,10 +45,11 @@ def publish_rawls(data: Dict[str, str]) -> None:
 
 
 def _get_subscriber_client() -> pubsub_v1.SubscriberClient:
-    global _subscriber_client
-    if _subscriber_client is None:
-        _subscriber_client = pubsub_v1.SubscriberClient(credentials=service_auth.get_isvc_credential())
-    return _subscriber_client
+    # global _subscriber_client
+    # if _subscriber_client is None:
+    #     _subscriber_client = pubsub_v1.SubscriberClient(credentials=service_auth.get_isvc_credential())
+    # return _subscriber_client
+    return pubsub_v1.SubscriberClient(credentials=service_auth.get_isvc_credential())
 
 
 def pull_self(num_messages: int):

--- a/app/tests/test_translate.py
+++ b/app/tests/test_translate.py
@@ -37,7 +37,7 @@ def get_memory_usage_mb():
 def maybe_himem_work(numbers_path: str, translator: Translator):
     with open(numbers_path, 'r') as read_numbers:
         with open(os.devnull, 'wb') as dev_null:
-            translate._stream_translate(read_numbers, dev_null, translator)
+            translate._stream_translate("unittest", read_numbers, dev_null, translator)
 
 
 def test_stream_translate(tmp_path):


### PR DESCRIPTION
fixes a few things I found while working on AS-456:
1. increase GAE hardware size, to try to make translation faster
2. use a new pubsub client for every message, so we don't try to reuse stale credentials and fail to auth
3. fix a serialization problem in an error case that made the error look worse than it was; this helps developers trying to debug problems
4. regularly log an "I'm still translating" message during translations, so we know the process is still active; this helps developers trying to debug problems