### PR TITLE
AS-505: create all attrs in pfb: namespace [risk: low]

### DIFF
--- a/app/tests/test_translate.py
+++ b/app/tests/test_translate.py
@@ -16,13 +16,13 @@ import pytest
 
 class StreamyNoOpTranslator(Translator):
     """Well-behaved no-op translator: does nothing, while streaming"""
-    def translate(self, file_like: IO) -> Iterator[Dict[str, Any]]:
+    def translate(self, file_like: IO, file_type: str) -> Iterator[Dict[str, Any]]:
         return ({line: line} for line in file_like)
 
 
 class BadNoOpTranslator(Translator):
     """Badly-behaved no-op translator: does nothing, using lots of memory"""
-    def translate(self, file_like: IO) -> Iterator[Dict[str, Any]]:
+    def translate(self, file_like: IO, file_type: str) -> Iterator[Dict[str, Any]]:
         return iter([{line: line} for line in file_like])
 
 
@@ -37,7 +37,7 @@ def get_memory_usage_mb():
 def maybe_himem_work(numbers_path: str, translator: Translator):
     with open(numbers_path, 'r') as read_numbers:
         with open(os.devnull, 'wb') as dev_null:
-            translate._stream_translate("unittest", read_numbers, dev_null, translator)
+            translate._stream_translate("unittest", read_numbers, dev_null, "somefiletype", translator)
 
 
 def test_stream_translate(tmp_path):

--- a/app/translate.py
+++ b/app/translate.py
@@ -50,7 +50,7 @@ def handle(msg: Dict[str, str]) -> ImportStatusResponse:
 
             gcs_project = GCSFileSystem(os.environ.get("PUBSUB_PROJECT"), token=service_auth.get_isvc_credential())
             with gcs_project.open(dest_file, 'wb') as dest_upsert:
-                _stream_translate(import_id, pfb_file, dest_upsert, translator = FILETYPE_TRANSLATORS[import_details.filetype]())
+                _stream_translate(import_id, pfb_file, dest_upsert, import_details.filetype, translator = FILETYPE_TRANSLATORS[import_details.filetype]())
 
     except (FileNotFoundError, IOError, gcsfs.utils.HttpError, requests.exceptions.ProxyError) as e:
         # These are errors thrown by the gcsfs library, see here:
@@ -88,8 +88,8 @@ def handle(msg: Dict[str, str]) -> ImportStatusResponse:
     return ImportStatusResponse(import_id, ImportStatus.ReadyForUpsert.name, None)
 
 
-def _stream_translate(import_id: str, source: IO, dest: IO, translator: Translator) -> None:
-    translated_gen = translator.translate(source)  # doesn't actually translate, just returns a generator
+def _stream_translate(import_id: str, source: IO, dest: IO, file_type: str, translator: Translator) -> None:
+    translated_gen = translator.translate(source, file_type)  # doesn't actually translate, just returns a generator
 
     start_time = time()
     last_log_time = time()

--- a/app/translators/pfb_to_rawls.py
+++ b/app/translators/pfb_to_rawls.py
@@ -11,7 +11,7 @@ class PFBToRawls(Translator):
         defaults = {'b64-decode-enums': False, 'prefix-object-ids': True}
         self.options = {**defaults, **options}
 
-    def translate(self, file_like) -> Iterator[Dict[str, Any]]:
+    def translate(self, file_like, file_type) -> Iterator[Dict[str, Any]]:
         with PFBReader(file_like) as reader:
             schema = reader.schema
             enums = self.list_enums(schema)
@@ -22,9 +22,9 @@ class PFBToRawls(Translator):
             # more than once.
             for record in reader:
                 if record['name'] != 'Metadata':
-                    yield self.translate_record(record, enums)
+                    yield self.translate_record(record, enums, file_type)
 
-    def translate_record(self, record, enums) -> Dict[str, Any]:
+    def translate_record(self, record, enums, file_type) -> Dict[str, Any]:
         entity_type = record['name']
         name = record['id']
 
@@ -36,7 +36,7 @@ class PFBToRawls(Translator):
             if key == 'name':
                 key = entity_type + '_name'
             else:
-                key = 'pfb:' + key
+                key = file_type + ':' + key
             return self.make_add_update_op(key, value)
 
         attributes = [make_op(key, value)

--- a/app/translators/pfb_to_rawls.py
+++ b/app/translators/pfb_to_rawls.py
@@ -35,6 +35,8 @@ class PFBToRawls(Translator):
                 value = 'drs://' + value
             if key == 'name':
                 key = entity_type + '_name'
+            else:
+                key = 'pfb:' + key
             return self.make_add_update_op(key, value)
 
         attributes = [make_op(key, value)

--- a/app/translators/translator.py
+++ b/app/translators/translator.py
@@ -4,5 +4,5 @@ from typing import Iterator, Dict, IO, Any
 
 class Translator(ABC):
     @abstractmethod
-    def translate(self, file_like: IO) -> Iterator[Dict[str, Any]]:
+    def translate(self, file_like: IO, file_type: str) -> Iterator[Dict[str, Any]]:
         pass


### PR DESCRIPTION
DO NOT MERGE - for review only. This will break the [cross-org BDC integration test](https://docs.google.com/document/d/1MXXjh6x9RfPwIqaesjq1k2V1r5KJ0Wt7P9P47ZIh4Zw/edit?usp=sharing). I have messages out to discuss how to fix that.

See https://docs.google.com/document/d/1B2QKTA2N9LsMrd0H1uRqtV2RbnunFNuSyirYUDkQzMI/edit?usp=sharing for full context.

This PR changes Import Service so that it creates all imported attributes in the `pfb:` namespace. It requires broadinstitute/rawls#1287 to succeed.

More accurately, it creates all imported attributes in a namespace equal to the "filetype" argument passed in to the import request. Currently, the only filetype that Import Service allows is "pfb" - but if in the future we support "avro" or "parquet" filetypes or something else, we'd create the attributes in those namespaces. We may also in the future add some other argument such as a "schemaName" or such.

_screenshot of PFB import, after this PR:_
![Screenshot (4)](https://user-images.githubusercontent.com/6041577/95362728-7a9d9480-089c-11eb-968a-8dd149ec6352.png)

This PR will break an orchestration integration test. broadinstitute/firecloud-orchestration#805 is waiting and ready to fix that test.