### PR TITLE
move to appsec blessed base image [no ticket; risk: low]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/base/python:distroless
+FROM us.gcr.io/broad-dsp-gcr-public/base/python:debian
 
 RUN apt-get update -y && \
     apt-get install -y python-pip python-dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.4
+FROM us.gcr.io/broad-dsp-gcr-public/base/python:distroless
 
 RUN apt-get update -y && \
     apt-get install -y python-pip python-dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,19 @@
+FROM python:3.9.1 AS build
+
+RUN python3 -m venv /venv
+
+# Install Python dependencies into the virtualenv
+COPY requirements.txt /
+RUN /venv/bin/pip install -r /requirements.txt
+RUN /venv/bin/pip install gunicorn
+
 FROM us.gcr.io/broad-dsp-gcr-public/base/python:debian
 
-RUN apt-get update -y && \
-    apt-get install -y python-pip python-dev
-
-# We copy just the requirements.txt first to leverage Docker cache
-COPY ./requirements.txt /app/requirements.txt
-
 WORKDIR /app
-
-RUN pip install -r requirements.txt
-
-RUN pip install gunicorn
-
-COPY . /app
+COPY --from=build /venv /venv
+COPY . .
 
 EXPOSE 8080
 
 CMD gunicorn -b :8080 main:app
+# ENTRYPOINT ["/venv/bin/python3", "main.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,3 @@ COPY . .
 EXPOSE 8080
 
 CMD /venv/bin/gunicorn -b :8080 main:app
-# ENTRYPOINT ["/venv/bin/python3", "main.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,5 @@ COPY . .
 
 EXPOSE 8080
 
-CMD gunicorn -b :8080 main:app
+CMD /venv/bin/gunicorn -b :8080 main:app
 # ENTRYPOINT ["/venv/bin/python3", "main.py"]


### PR DESCRIPTION
The Dockerfile in this repo is only used inside of FiaBs. It is not used at runtime in production, since we deploy to GAE Standard instead.

For good measure, I'm updating the Dockerfile to use an appsec-blessed docker base image. As part of this move,  I had to refactor it to a multi-stage build, following the example at https://github.com/broadinstitute/dsp-appsec-blessed-images/tree/main/python.

I tested this by 1) verifying that Quay successfully built the image, and 2) manually running a swatomation-pipeline against the tag for this PR.