### PR TITLE
fixed dependency conflict from new pip versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ google-cloud-pubsub==1.1.0
 oauth2client==4.1.3
 pypfb==0.4.3
 gcsfs==0.6.0
-memunit==0.5.0
-psutil==5.6.7
+memunit==0.5.2
+psutil==5.7.0
 pyhumps==1.3.1
 flask-restx==0.1.1


### PR DESCRIPTION
Updated psutil and memunit to avoid dependency conflict that arises in newer versions of pip. No new functionality, All pytests still pass.