### PR TITLE
support upsert vs. update mode [AS-916]

### DIFF
--- a/app/db/model.py
+++ b/app/db/model.py
@@ -7,6 +7,7 @@ from sqlalchemy import Column, DateTime, String
 from sqlalchemy.schema import Table
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import validates
+from sqlalchemy.sql.sqltypes import Boolean
 from sqlalchemy_repr import RepresentableBase
 from app.db import DBSession
 
@@ -115,6 +116,7 @@ class Import(ImportServiceTable, EqMixin, Base):
     status = Column(Enum(ImportStatus), nullable=False)
     filetype = Column(String(10), nullable=False)
     error_message = Column(String(2048), nullable=True)
+    is_upsert = Column(Boolean, nullable=False, default=True)
 
     @validates('error_message')
     def truncate(self, key, value):
@@ -124,7 +126,7 @@ class Import(ImportServiceTable, EqMixin, Base):
             return value[:max_len]
         return value
 
-    def __init__(self, workspace_name: str, workspace_ns: str, workspace_uuid: str, submitter: str, import_url: str, filetype: str):
+    def __init__(self, workspace_name: str, workspace_ns: str, workspace_uuid: str, submitter: str, import_url: str, filetype: str, is_upsert: bool = True):
         self.id = str(uuid.uuid4())
         self.workspace_name = workspace_name
         self.workspace_namespace = workspace_ns
@@ -135,6 +137,7 @@ class Import(ImportServiceTable, EqMixin, Base):
         self.status = ImportStatus.Pending
         self.filetype = filetype
         self.error_message = None
+        self.is_upsert = is_upsert
 
     @classmethod
     def get(cls, id: str, sess: DBSession) -> ImportT:

--- a/app/db/model.py
+++ b/app/db/model.py
@@ -127,7 +127,7 @@ class Import(ImportServiceTable, EqMixin, Base):
         return value
 
     def __init__(self, workspace_name: str, workspace_ns: str, workspace_uuid: str, submitter: str, import_url: str, filetype: str, is_upsert: bool = True):
-        """init method for Import model."""
+        """Init method for Import model."""
         self.id = str(uuid.uuid4())
         self.workspace_name = workspace_name
         self.workspace_namespace = workspace_ns

--- a/app/db/model.py
+++ b/app/db/model.py
@@ -127,6 +127,7 @@ class Import(ImportServiceTable, EqMixin, Base):
         return value
 
     def __init__(self, workspace_name: str, workspace_ns: str, workspace_uuid: str, submitter: str, import_url: str, filetype: str, is_upsert: bool = True):
+        """init method for Import model."""
         self.id = str(uuid.uuid4())
         self.workspace_name = workspace_name
         self.workspace_namespace = workspace_ns

--- a/app/new_import.py
+++ b/app/new_import.py
@@ -19,9 +19,13 @@ def handle(request: flask.Request, ws_ns: str, ws_name: str) -> model.ImportStat
     # TODO: AS-155: change to "url"?
     import_url = request_json["path"]
     import_filetype = request_json["filetype"]
+    import_is_upsert = request_json.get("isUpsert", "true") # default to true if missing, to support legacy imports
 
     # and validate the input's path
     translate.validate_import_url(import_url, import_filetype, user_info)
+
+    # parse is_upsert from a str into a bool
+    is_upsert = str(import_is_upsert).lower == "true"
 
     new_import = model.Import(
         workspace_name=ws_name,
@@ -29,7 +33,8 @@ def handle(request: flask.Request, ws_ns: str, ws_name: str) -> model.ImportStat
         workspace_uuid=workspace_uuid,
         submitter=user_info.user_email,
         import_url=import_url,
-        filetype=request_json["filetype"])
+        filetype=request_json["filetype"],
+        is_upsert=is_upsert)
 
     with db.session_ctx() as sess:
         sess.add(new_import)

--- a/app/new_import.py
+++ b/app/new_import.py
@@ -25,7 +25,7 @@ def handle(request: flask.Request, ws_ns: str, ws_name: str) -> model.ImportStat
     translate.validate_import_url(import_url, import_filetype, user_info)
 
     # parse is_upsert from a str into a bool
-    is_upsert = str(import_is_upsert).lower == "true"
+    is_upsert = str(import_is_upsert).strip().lower() == "true"
 
     new_import = model.Import(
         workspace_name=ws_name,

--- a/app/server/routes.py
+++ b/app/server/routes.py
@@ -29,7 +29,8 @@ ns = api.namespace('/', description='import handling')
 
 new_import_model = ns.model("NewImport",
                              {"path": fields.String(required=True),
-                              "filetype": fields.String(enum=list(translate.FILETYPE_TRANSLATORS.keys()) + [translate.FILETYPE_NOTRANSLATION], required=True)})
+                              "filetype": fields.String(enum=list(translate.FILETYPE_TRANSLATORS.keys()) + [translate.FILETYPE_NOTRANSLATION], required=True),
+                              "isUpsert": fields.Boolean(required=False, default=True)})
 import_status_response_model = ns.model("ImportStatusResponse", model.ImportStatusResponse.get_model())
 health_response_model = ns.model("HealthResponse", health.HealthResponse.get_model(api))
 

--- a/app/tests/test_model.py
+++ b/app/tests/test_model.py
@@ -60,3 +60,31 @@ def test_importstatus_enum_fromstring():
 
     with pytest.raises(NotImplementedError):
         ImportStatus.from_string("not a valid enum string")
+
+def test_import_is_upsert_default():
+    """Import model sets is_upsert to True when omitted"""
+
+    new_import = model.Import(
+        workspace_name="ws_name",
+        workspace_ns="ws_ns",
+        workspace_uuid="workspace_uuid",
+        submitter="user_info.user_email",
+        import_url="import_url",
+        filetype="filetype")
+
+    assert new_import.is_upsert == True
+
+@pytest.mark.parametrize("is_upsert", [True, False])
+def test_import_is_upsert_allows_setting_false(is_upsert):
+    """Import model sets is_upsert appropriately when specified"""
+
+    new_import = model.Import(
+        workspace_name="ws_name",
+        workspace_ns="ws_ns",
+        workspace_uuid="workspace_uuid",
+        submitter="user_info.user_email",
+        import_url="import_url",
+        filetype="filetype",
+        is_upsert=is_upsert)
+
+    assert new_import.is_upsert == is_upsert

--- a/app/tests/test_model.py
+++ b/app/tests/test_model.py
@@ -62,8 +62,7 @@ def test_importstatus_enum_fromstring():
         ImportStatus.from_string("not a valid enum string")
 
 def test_import_is_upsert_default():
-    """Import model sets is_upsert to True when omitted"""
-
+    """Import model sets is_upsert to True when omitted."""
     new_import = model.Import(
         workspace_name="ws_name",
         workspace_ns="ws_ns",
@@ -76,8 +75,7 @@ def test_import_is_upsert_default():
 
 @pytest.mark.parametrize("is_upsert", [True, False])
 def test_import_is_upsert_allows_setting_false(is_upsert):
-    """Import model sets is_upsert appropriately when specified"""
-
+    """Import model sets is_upsert appropriately when specified."""
     new_import = model.Import(
         workspace_name="ws_name",
         workspace_ns="ws_ns",

--- a/app/tests/test_model.py
+++ b/app/tests/test_model.py
@@ -71,7 +71,7 @@ def test_import_is_upsert_default():
         import_url="import_url",
         filetype="filetype")
 
-    assert new_import.is_upsert == True
+    assert new_import.is_upsert
 
 @pytest.mark.parametrize("is_upsert", [True, False])
 def test_import_is_upsert_allows_setting_false(is_upsert):

--- a/app/tests/test_new_import.py
+++ b/app/tests/test_new_import.py
@@ -112,7 +112,7 @@ def test_is_upsert_is_false_when_falsey_in_json(input_value, client):
     dbres = sess.query(Import).filter(Import.id == id).all()
     assert len(dbres) == 1
     # assert that the db row contains True for is_upsert
-    assert dbres[0].is_upsert == False
+    assert not dbres[0].is_upsert
 
 @pytest.mark.parametrize("input_value", ["true", "tRuE", "  TRUE  ", True])
 @pytest.mark.usefixtures("sam_valid_user", "user_has_ws_access", "pubsub_publish", "pubsub_fake_env")

--- a/app/tests/test_new_import.py
+++ b/app/tests/test_new_import.py
@@ -84,7 +84,7 @@ def test_user_cant_write_to_workspace(client):
     assert resp.status_code == 403
 
 @pytest.mark.usefixtures("sam_valid_user", "user_has_ws_access", "pubsub_publish", "pubsub_fake_env")
-def test_is_upsert_defaults_true_when_missing(client):
+def test_is_upsert_defaults_true_when_missing_from_json(client):
     json_payload = {"path": f"https://{translate.VALID_NETLOCS[0]}/some/path", "filetype": "pfb"}
 
     resp = client.post('/mynamespace/myname/imports', json=json_payload, headers=good_headers)
@@ -98,10 +98,9 @@ def test_is_upsert_defaults_true_when_missing(client):
     # assert that the db row contains True for is_upsert
     assert dbres[0].is_upsert
 
-@pytest.mark.parametrize("input_value", ["false", "False", 0, "something else", "", False])
 @pytest.mark.usefixtures("sam_valid_user", "user_has_ws_access", "pubsub_publish", "pubsub_fake_env")
-def test_is_upsert_is_false_when_falsey_in_json(input_value, client):
-    json_payload = {"path": f"https://{translate.VALID_NETLOCS[0]}/some/path", "filetype": "pfb", "isUpsert": input_value}
+def test_is_upsert_is_false_when_false_in_json(client):
+    json_payload = {"path": f"https://{translate.VALID_NETLOCS[0]}/some/path", "filetype": "pfb", "isUpsert": False}
 
     resp = client.post('/mynamespace/myname/imports', json=json_payload, headers=good_headers)
     assert resp.status_code == 201
@@ -114,10 +113,9 @@ def test_is_upsert_is_false_when_falsey_in_json(input_value, client):
     # assert that the db row contains True for is_upsert
     assert not dbres[0].is_upsert
 
-@pytest.mark.parametrize("input_value", ["true", "tRuE", "  TRUE  ", True])
 @pytest.mark.usefixtures("sam_valid_user", "user_has_ws_access", "pubsub_publish", "pubsub_fake_env")
-def test_is_upsert_is_true_when_truthy_in_json(input_value, client):
-    json_payload = {"path": f"https://{translate.VALID_NETLOCS[0]}/some/path", "filetype": "pfb", "isUpsert": input_value}
+def test_is_upsert_is_true_when_true_in_json(client):
+    json_payload = {"path": f"https://{translate.VALID_NETLOCS[0]}/some/path", "filetype": "pfb", "isUpsert": True}
 
     resp = client.post('/mynamespace/myname/imports', json=json_payload, headers=good_headers)
     assert resp.status_code == 201
@@ -129,3 +127,11 @@ def test_is_upsert_is_true_when_truthy_in_json(input_value, client):
     assert len(dbres) == 1
     # assert that the db row contains True for is_upsert
     assert dbres[0].is_upsert
+
+@pytest.mark.parametrize("input_value", ["true", "True", "yes", 1, "false", "False", "no", 0, "", "something else"])
+@pytest.mark.usefixtures("sam_valid_user", "user_has_ws_access", "pubsub_publish", "pubsub_fake_env")
+def test_bad_request_when_isUpsert_is_not_boolean(input_value, client):
+    json_payload = {"path": f"https://{translate.VALID_NETLOCS[0]}/some/path", "filetype": "pfb", "isUpsert": input_value}
+
+    resp = client.post('/mynamespace/myname/imports', json=json_payload, headers=good_headers)
+    assert resp.status_code == 400

--- a/app/tests/test_translate.py
+++ b/app/tests/test_translate.py
@@ -145,7 +145,7 @@ def test_golden_path(fake_import, fake_publish_rawls, client):
 @pytest.mark.parametrize("is_upsert", [True, False])
 @pytest.mark.usefixtures("good_http_pfb", "good_gcs_dest", "incoming_valid_pubsub")
 def test_publish_rawls_is_upsert_passed_on(is_upsert, fake_publish_rawls, client):
-    """is_upsert value from the database is sent along to Rawls in the pubsub message"""
+    """is_upsert value from the database is sent along to Rawls in the pubsub message."""
     test_import = model.Import("bb", "bb", "uuid", "bb@bb.bb", "gs://bb/bb", "pfb", is_upsert=is_upsert)
 
     with db.session_ctx() as sess:

--- a/app/translate.py
+++ b/app/translate.py
@@ -92,7 +92,8 @@ def handle(msg: Dict[str, str]) -> ImportStatusResponse:
         "workspaceName": import_details.workspace_name,
         "userEmail": import_details.submitter,
         "jobId": import_details.id,
-        "upsertFile": dest_file
+        "upsertFile": dest_file,
+        "isUpsert": str(import_details.is_upsert)
     })
 
     return ImportStatusResponse(import_id, ImportStatus.ReadyForUpsert.name, None)

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,4 +24,4 @@ gcsfs==2021.04.0
 memunit==0.5.2
 psutil==5.7.0
 pyhumps==1.3.1
-flask-restx==0.1.1
+flask-restx==0.5.1


### PR DESCRIPTION
AS-916

Import Service now accepts an optional isUpsert key in the request payload for creating an import job. If omitted, isUpsert defaults to true. The isUpsert value is persisted to the database as an attribute of the import job, and the value is sent along in the pubsub message that Import Service publishes to Rawls, to control the behavior of Rawls' writes. The corresponding Rawls PR is broadinstitute/rawls#1509.

This change is necessary to fully support asynchronous TSV import. Without this change, we could only support entity and membership TSVs, we could not support update TSVs.

TODO:
- [ ] this PR requires a new column in the the Import Service database table `imports`. Because we do not have a schema-migration system in place for Import Service (AS-184), I will manually create that column in the persistent environments once this PR is approved and ready to deploy.