### PR TITLE
possible bugfix for session handling

### DIFF
--- a/app/db/db.py
+++ b/app/db/db.py
@@ -17,6 +17,7 @@ _sessionmaker = None
 
 def get_session() -> DBSession:
     global _db
+    global _sessionmaker
 
     if _db is None:
         _db = sqlalchemy.create_engine(


### PR DESCRIPTION
Hey folks. I still crib from import-service when I'm working on a Python project and I think I've noticed a mistake here. SQLAlchemy's `sessionmaker` is a session factory. Its intended usage is something like:

```
sessionmaker = sqlalchemy.orm.sessionmaker(bind=_db, ...blah blah...)

 # now get some sessions (imagine this is being called from other code)
session1 = sessionmaker()
session2 = sessionmaker()
```

Import service's code for `get_session()` is creating a sessionmaker every single time it's called. It's (probably) not going to cause any problems, but it only needs to be constructed once. This PR does that by creating the sessionmaker alongside the db engine singleton.

Obviously I haven't tested it on GAE etc. Hope y'all are well!