### PR TITLE
possible bugfix for session handling (copy) [AS-1005]

### DIFF
--- a/app/db/db.py
+++ b/app/db/db.py
@@ -31,6 +31,7 @@ def get_session() -> DBSession:
         logging.info("Creating new database tables...")
         model.Base.metadata.create_all(_db)
 
+    if _sessionmaker is None:
         # NOTE on the use of expire_on_commit = False here.
         # We often need to access attributes on an import object after a session is closed.
         # By default, the session will "expire" the object on commit, which makes further attribute access throw an exception.
@@ -38,6 +39,7 @@ def get_session() -> DBSession:
         # expire_on_commit = False disables this behaviour. We pair this with session.expunge_all() when closing a
         # transaction, which detaches the object without invalidating access to its attributes.
         _sessionmaker = sqlalchemy.orm.sessionmaker(bind=_db, expire_on_commit=False)
+
     return _sessionmaker()
 
 

--- a/app/db/db.py
+++ b/app/db/db.py
@@ -12,10 +12,12 @@ db_connection_name = os.environ.get("CLOUD_SQL_CONNECTION_NAME")
 
 # Store the db so it can be reused between GAE invocations.
 _db = None
+_sessionmaker = None
 
 
 def get_session() -> DBSession:
     global _db
+    global _sessionmaker
 
     if _db is None:
         _db = sqlalchemy.create_engine(
@@ -29,16 +31,14 @@ def get_session() -> DBSession:
         logging.info("Creating new database tables...")
         model.Base.metadata.create_all(_db)
 
-    # NOTE on the use of expire_on_commit = False here.
-    # We often need to access attributes on an import object after a session is closed.
-    # By default, the session will "expire" the object on commit, which makes further attribute access throw an exception.
-    # See https://docs.sqlalchemy.org/en/13/orm/session_state_management.html for sqlalchemy object states.
-    # expire_on_commit = False disables this behaviour. We pair this with session.expunge_all() when closing a
-    # transaction, which detaches the object without invalidating access to its attributes.
-    sessionmaker = sqlalchemy.orm.sessionmaker(bind=_db, expire_on_commit=False)
-    session = sessionmaker()
-
-    return session
+        # NOTE on the use of expire_on_commit = False here.
+        # We often need to access attributes on an import object after a session is closed.
+        # By default, the session will "expire" the object on commit, which makes further attribute access throw an exception.
+        # See https://docs.sqlalchemy.org/en/13/orm/session_state_management.html for sqlalchemy object states.
+        # expire_on_commit = False disables this behaviour. We pair this with session.expunge_all() when closing a
+        # transaction, which detaches the object without invalidating access to its attributes.
+        _sessionmaker = sqlalchemy.orm.sessionmaker(bind=_db, expire_on_commit=False)
+    return _sessionmaker()
 
 
 @contextmanager


### PR DESCRIPTION
making a copy of #66 within the broadinstitute org, to get full automated tests running. See that other PR for description/explanation.

This PR adds a second commit to check _sessionmaker and _db separately. Without this fix, unit tests were failing.