### PR TITLE
use same python image for build and run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/base/python:debian AS build
+FROM python:3.10 AS build
 
 RUN python3 -m venv /venv
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.5 AS build
+FROM us.gcr.io/broad-dsp-gcr-public/base/python:debian AS build
 
 RUN python3 -m venv /venv
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10 AS build
+FROM us.gcr.io/broad-dsp-gcr-public/base/python:debian AS build
 
 RUN python3 -m venv /venv
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ setuptools==42.0.2
 wheel==0.33.6
 Flask==1.1.1
 Werkzeug==0.16.0
-MarkupSafe==1.1.1
+MarkupSafe==2.0.1
 Jinja2==2.11.3
 jsonschema==3.2.0
 pytest==5.3.1


### PR DESCRIPTION
Since we're using `us.gcr.io/broad-dsp-gcr-public/base/python:debian` to run import-service, let's also use `us.gcr.io/broad-dsp-gcr-public/base/python:debian` to do all the `pip install` work when building the docker image. This guarantees that the python versions used for installing requirements and running will always be the same … even though it's super difficult that that's a floating version that can change out from under us.