### PR TITLE
noop translate returns one hardcoded entity [AS-1035]

### DIFF
--- a/app/tests/test_parquet_to_rawls.py
+++ b/app/tests/test_parquet_to_rawls.py
@@ -1,4 +1,5 @@
 from app.translators.parquet_to_rawls import ParquetToRawls
+from app.translators.parquet_to_rawls import SAMPLE_ENTITY
 
 import pytest
 
@@ -9,6 +10,9 @@ def test_noop_translate_parquet(fake_import_parquet):
     """Proper translation of parquet files to rawls json."""
     translator = ParquetToRawls()
     result_iterator = translator.translate(fake_import_parquet, "tdrexport")
+    # result_iterator should have one entity in it:
+    assert next(result_iterator) == SAMPLE_ENTITY
+    # and since there's only one entity, we should see StopIteration when asking for anything beyond the first
     with pytest.raises(StopIteration):
         next(result_iterator)
 

--- a/app/tests/test_parquet_to_rawls.py
+++ b/app/tests/test_parquet_to_rawls.py
@@ -3,7 +3,7 @@ from app.translators.parquet_to_rawls import SAMPLE_ENTITY
 
 import pytest
 
-# this unit test asserts that the parquet translation results in an empty iterator.
+# this unit test asserts that the parquet translation results in an iterator with one hardcoded entity in it.
 # this test is only valid for the noop end-to-end spike, in which we don't actually look inside the parquet file.
 # once we implement real parquet translation, this test must be deleted or updated.
 def test_noop_translate_parquet(fake_import_parquet):

--- a/app/translators/parquet_to_rawls.py
+++ b/app/translators/parquet_to_rawls.py
@@ -3,6 +3,17 @@ import logging
 from app.translators.translator import Translator
 from typing import Iterator, Dict, Any
 
+SAMPLE_ENTITY = {
+    'name': 'tdrexport',
+    'entityType': 'tdrexport',
+    'operations': [
+        {
+            'op': 'AddUpdateAttribute',
+            'attributeName': 'description',
+            'addUpdateAttribute': 'this is a hardcoded entity and attribute to test the snapshot import flow'
+        }
+    ]
+}
 
 class ParquetToRawls(Translator):
     def __init__(self, options=None):
@@ -14,4 +25,4 @@ class ParquetToRawls(Translator):
 
     def translate(self, file_like, file_type) -> Iterator[Dict[str, Any]]:
         logging.info(f"executing a no-op ParquetToRawls translation for {file_type}: {file_like}")
-        return iter([])
+        return iter([SAMPLE_ENTITY])


### PR DESCRIPTION
instead of returning zero rows from the noop `tdrexport` translator, return one hardcoded entity. This makes it easier to see that it is working correctly from Rawls/Orch/UI.