### PR TITLE
add workspace_google_project to Import model [AS-1037]

### DIFF
--- a/app/auth/user_auth.py
+++ b/app/auth/user_auth.py
@@ -5,6 +5,7 @@ import logging
 
 from app.util.exceptions import AuthorizationException
 from app.external import rawls
+from app.external.rawls import RawlsWorkspaceResponse
 
 
 def extract_auth_token(request: flask.Request) -> str:
@@ -18,7 +19,7 @@ def extract_auth_token(request: flask.Request) -> str:
     return token
 
 
-def workspace_uuid_and_project_with_auth(workspace_ns: str, workspace_name: str, bearer_token: str, sam_action: str = "read") -> Dict[str, str]:
+def workspace_uuid_and_project_with_auth(workspace_ns: str, workspace_name: str, bearer_token: str, sam_action: str = "read") -> RawlsWorkspaceResponse:
     """Checks Rawls to get the workspace UUID, and then checks Sam to see if the user has the given action on the workspace resource.
     If so, returns the workspace UUID."""
     uuid_and_project = rawls.get_workspace_uuid_and_project(workspace_ns, workspace_name, bearer_token)

--- a/app/auth/user_auth.py
+++ b/app/auth/user_auth.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Optional
 
 import flask
 import logging

--- a/app/auth/user_auth.py
+++ b/app/auth/user_auth.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Dict, Optional
 
 import flask
 import logging
@@ -18,10 +18,10 @@ def extract_auth_token(request: flask.Request) -> str:
     return token
 
 
-def workspace_uuid_with_auth(workspace_ns: str, workspace_name: str, bearer_token: str, sam_action: str = "read") -> str:
+def workspace_uuid_and_project_with_auth(workspace_ns: str, workspace_name: str, bearer_token: str, sam_action: str = "read") -> Dict[str, str]:
     """Checks Rawls to get the workspace UUID, and then checks Sam to see if the user has the given action on the workspace resource.
     If so, returns the workspace UUID."""
-    ws_uuid = rawls.get_workspace_uuid(workspace_ns, workspace_name, bearer_token)
+    uuid_and_project = rawls.get_workspace_uuid_and_project(workspace_ns, workspace_name, bearer_token)
 
     # the read check is done when you ask rawls for the workspace UUID, so don't redo it
     if sam_action != "read" and not rawls.check_workspace_iam_action(workspace_ns, workspace_name, sam_action, bearer_token):
@@ -29,4 +29,4 @@ def workspace_uuid_with_auth(workspace_ns: str, workspace_name: str, bearer_toke
         logging.info(f"User has read action on workspace {workspace_ns}/{workspace_name}, but cannot perform {sam_action}.")
         raise AuthorizationException(f"Cannot perform the action {sam_action} on {workspace_ns}/{workspace_name}.")
 
-    return ws_uuid
+    return uuid_and_project

--- a/app/db/model.py
+++ b/app/db/model.py
@@ -110,6 +110,7 @@ class Import(ImportServiceTable, EqMixin, Base):
     workspace_name = Column(String(100), nullable=False)
     workspace_namespace = Column(String(100), nullable=False)
     workspace_uuid = Column(String(36), nullable=False)
+    workspace_google_project = Column(String(30), nullable=False)
     submitter = Column(String(100), nullable=False)
     import_url = Column(String(2048), nullable=False)  # max url length: https://stackoverflow.com/q/417142/2941784
     submit_time = Column(DateTime, nullable=False)
@@ -126,12 +127,13 @@ class Import(ImportServiceTable, EqMixin, Base):
             return value[:max_len]
         return value
 
-    def __init__(self, workspace_name: str, workspace_ns: str, workspace_uuid: str, submitter: str, import_url: str, filetype: str, is_upsert: bool = True):
+    def __init__(self, workspace_name: str, workspace_ns: str, workspace_uuid: str, workspace_google_project: str, submitter: str, import_url: str, filetype: str, is_upsert: bool = True):
         """Init method for Import model."""
         self.id = str(uuid.uuid4())
         self.workspace_name = workspace_name
         self.workspace_namespace = workspace_ns
         self.workspace_uuid = workspace_uuid
+        self.workspace_google_project = workspace_google_project
         self.submitter = submitter
         self.import_url = import_url
         self.submit_time = datetime.now()

--- a/app/external/rawls.py
+++ b/app/external/rawls.py
@@ -4,17 +4,24 @@ import os
 import requests
 
 from app.util.exceptions import ISvcException
+from dataclasses import dataclass
 from typing import Dict
 
 
-def get_workspace_uuid_and_project(workspace_namespace: str, workspace_name: str, bearer_token: str) -> Dict[str, str]:
+@dataclass
+class RawlsWorkspaceResponse:
+     workspace_id: str
+     google_project: str
+
+
+def get_workspace_uuid_and_project(workspace_namespace: str, workspace_name: str, bearer_token: str) -> RawlsWorkspaceResponse:
     resp = requests.get(
         f"{os.environ.get('RAWLS_URL')}/api/workspaces/{workspace_namespace}/{workspace_name}?fields=workspace.workspaceId,workspace.googleProject",
         headers={"Authorization": bearer_token})
 
     if resp.ok:
         jso = resp.json()
-        return {"uuid": jso["workspace"]["workspaceId"], "googleProject": jso["workspace"]["googleProject"]}
+        return RawlsWorkspaceResponse(workspace_id=jso["workspace"]["workspaceId"], google_project=jso["workspace"]["googleProject"])
     else:
         # just pass the error upwards
         logging.info(f"Got {resp.status_code} from Rawls for {workspace_namespace}/{workspace_name}: {resp.text}")

--- a/app/external/rawls.py
+++ b/app/external/rawls.py
@@ -4,15 +4,17 @@ import os
 import requests
 
 from app.util.exceptions import ISvcException
+from typing import Dict
 
 
-def get_workspace_uuid(workspace_namespace: str, workspace_name: str, bearer_token: str) -> str:
+def get_workspace_uuid_and_project(workspace_namespace: str, workspace_name: str, bearer_token: str) -> Dict[str, str]:
     resp = requests.get(
-        f"{os.environ.get('RAWLS_URL')}/api/workspaces/{workspace_namespace}/{workspace_name}?fields=workspace.workspaceId",
+        f"{os.environ.get('RAWLS_URL')}/api/workspaces/{workspace_namespace}/{workspace_name}?fields=workspace.workspaceId,workspace.googleProject",
         headers={"Authorization": bearer_token})
 
     if resp.ok:
-        return resp.json()["workspace"]["workspaceId"]
+        jso = resp.json()
+        return {"uuid": jso["workspace"]["workspaceId"], "googleProject": jso["workspace"]["googleProject"]}
     else:
         # just pass the error upwards
         logging.info(f"Got {resp.status_code} from Rawls for {workspace_namespace}/{workspace_name}: {resp.text}")

--- a/app/external/rawls.py
+++ b/app/external/rawls.py
@@ -5,7 +5,6 @@ import requests
 
 from app.util.exceptions import ISvcException
 from dataclasses import dataclass
-from typing import Dict
 
 
 @dataclass

--- a/app/new_import.py
+++ b/app/new_import.py
@@ -14,9 +14,10 @@ def handle(request: flask.Request, ws_ns: str, ws_name: str) -> model.ImportStat
     request_json = request.get_json(force=True, silent=True)
 
     # make sure the user is allowed to import to this workspace
-    workspace_uuid = user_auth.workspace_uuid_with_auth(ws_ns, ws_name, access_token, "write")
+    uuid_and_project = user_auth.workspace_uuid_and_project_with_auth(ws_ns, ws_name, access_token, "write")
+    workspace_uuid = uuid_and_project["uuid"]
+    google_project = uuid_and_project["googleProject"]
 
-    # TODO: AS-155: change to "url"?
     import_url = request_json["path"]
     import_filetype = request_json["filetype"]
     import_is_upsert = request_json.get("isUpsert", "true") # default to true if missing, to support legacy imports
@@ -31,6 +32,7 @@ def handle(request: flask.Request, ws_ns: str, ws_name: str) -> model.ImportStat
         workspace_name=ws_name,
         workspace_ns=ws_ns,
         workspace_uuid=workspace_uuid,
+        workspace_google_project=google_project,
         submitter=user_info.user_email,
         import_url=import_url,
         filetype=request_json["filetype"],

--- a/app/new_import.py
+++ b/app/new_import.py
@@ -15,8 +15,8 @@ def handle(request: flask.Request, ws_ns: str, ws_name: str) -> model.ImportStat
 
     # make sure the user is allowed to import to this workspace
     uuid_and_project = user_auth.workspace_uuid_and_project_with_auth(ws_ns, ws_name, access_token, "write")
-    workspace_uuid = uuid_and_project["uuid"]
-    google_project = uuid_and_project["googleProject"]
+    workspace_uuid = uuid_and_project.workspace_id
+    google_project = uuid_and_project.google_project
 
     import_url = request_json["path"]
     import_filetype = request_json["filetype"]

--- a/app/status.py
+++ b/app/status.py
@@ -16,7 +16,7 @@ def handle_get_import_status(request: flask.Request, ws_ns: str, ws_name: str, i
     sam.validate_user(access_token)
 
     # make sure the user is allowed to view the workspace containing the import
-    user_auth.workspace_uuid_with_auth(ws_ns, ws_name, access_token, "read")
+    user_auth.workspace_uuid_and_project_with_auth(ws_ns, ws_name, access_token, "read")
 
     try:
         with db.session_ctx() as sess:
@@ -38,7 +38,7 @@ def handle_list_import_status(request: flask.Request, ws_ns: str, ws_name: str) 
     sam.validate_user(access_token)
 
     # make sure the user is allowed to view this workspace
-    user_auth.workspace_uuid_with_auth(ws_ns, ws_name, access_token, "read")
+    user_auth.workspace_uuid_and_project_with_auth(ws_ns, ws_name, access_token, "read")
 
     with db.session_ctx() as sess:
         q = sess.query(model.Import).\

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -63,11 +63,11 @@ def fresh_db(_db_internal: sqlalchemy.engine.Engine) -> Iterator[None]:
 
 @pytest.fixture(scope="function")
 def fake_import() -> Iterator[model.Import]:
-    yield model.Import("aa", "aa", "uuid", "aa@aa.aa", "gs://aa/aa", "pfb")
+    yield model.Import("aa", "aa", "uuid", "project", "aa@aa.aa", "gs://aa/aa", "pfb")
 
 @pytest.fixture(scope="function")
 def fake_import_parquet() -> Iterator[model.Import]:
-    yield model.Import("bb", "bb", "uuid2", "bb@bb.bb", "gs://bb/bb", "tdrexport")
+    yield model.Import("bb", "bb", "uuid2", "project2", "bb@bb.bb", "gs://bb/bb", "tdrexport")
 
 @pytest.fixture(scope="function")
 def incoming_valid_pubsub(monkeypatch) -> Iterator[None]:
@@ -107,8 +107,8 @@ def sam_valid_user(monkeypatch):
 @pytest.fixture(scope="function")
 def user_has_ws_access(monkeypatch):
     """Makes us think that the user has access to the workspace in Rawls."""
-    monkeypatch.setattr("app.auth.user_auth.workspace_uuid_with_auth",
-                        mock.MagicMock(return_value="some-uuid"))
+    monkeypatch.setattr("app.auth.user_auth.workspace_uuid_and_project_with_auth",
+                        mock.MagicMock(return_value={"uuid":"some-uuid", "googleProject":"some-project"}))
 
 
 @pytest.fixture(scope="function")

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -17,6 +17,7 @@ from unittest import mock
 from app import create_app
 from app.auth import service_auth, userinfo
 from app.db import db, model
+from app.external.rawls import RawlsWorkspaceResponse
 
 
 def _test_client() -> flask.testing.FlaskClient:
@@ -108,7 +109,7 @@ def sam_valid_user(monkeypatch):
 def user_has_ws_access(monkeypatch):
     """Makes us think that the user has access to the workspace in Rawls."""
     monkeypatch.setattr("app.auth.user_auth.workspace_uuid_and_project_with_auth",
-                        mock.MagicMock(return_value={"uuid":"some-uuid", "googleProject":"some-project"}))
+                        mock.MagicMock(return_value=RawlsWorkspaceResponse("some-uuid", "some-project")))
 
 
 @pytest.fixture(scope="function")

--- a/app/tests/test_db.py
+++ b/app/tests/test_db.py
@@ -5,6 +5,7 @@ def test_db_add():
     new_import = model.Import(workspace_name="wsName",
                               workspace_ns="wsNs",
                               workspace_uuid="ws-uuid",
+                              workspace_google_project="google-project",
                               submitter="hussein@coolguy.email",
                               import_url="gs://import/me.pfb",
                               filetype="pfb")

--- a/app/tests/test_model.py
+++ b/app/tests/test_model.py
@@ -67,6 +67,7 @@ def test_import_is_upsert_default():
         workspace_name="ws_name",
         workspace_ns="ws_ns",
         workspace_uuid="workspace_uuid",
+        workspace_google_project="google-project",
         submitter="user_info.user_email",
         import_url="import_url",
         filetype="filetype")
@@ -80,6 +81,7 @@ def test_import_is_upsert_allows_setting_false(is_upsert):
         workspace_name="ws_name",
         workspace_ns="ws_ns",
         workspace_uuid="workspace_uuid",
+        workspace_google_project="google-project",
         submitter="user_info.user_email",
         import_url="import_url",
         filetype="filetype",

--- a/app/tests/test_new_import.py
+++ b/app/tests/test_new_import.py
@@ -67,7 +67,7 @@ def test_user_not_found(client):
 @pytest.mark.usefixtures(
     "sam_valid_user",
     testutils.fxpatch(
-        "app.auth.user_auth.workspace_uuid_with_auth",
+        "app.auth.user_auth.workspace_uuid_and_project_with_auth",
         side_effect = exceptions.ISvcException("what workspace?", 404)))
 def test_user_cant_see_workspace(client):
     resp = client.post('/namespace/name/imports', json=good_json, headers=good_headers)
@@ -77,7 +77,7 @@ def test_user_cant_see_workspace(client):
 @pytest.mark.usefixtures(
     "sam_valid_user",
     testutils.fxpatch(
-        "app.auth.user_auth.workspace_uuid_with_auth",
+        "app.auth.user_auth.workspace_uuid_and_project_with_auth",
         side_effect = exceptions.ISvcException("you can't write to this", 403)))
 def test_user_cant_write_to_workspace(client):
     resp = client.post('/namespace/name/imports', json=good_json, headers=good_headers)

--- a/app/tests/test_rawls.py
+++ b/app/tests/test_rawls.py
@@ -9,16 +9,16 @@ def test_get_workspace_uuid():
     # rawls returns non-OK response
     with testutils.patch_request("app.external.rawls", "get", status_code = 403, text="no"):
         with pytest.raises(exceptions.ISvcException):
-            rawls.get_workspace_uuid("a", "a", "a")
+            rawls.get_workspace_uuid_and_project("a", "a", "a")
 
     # rawls returns ok response with dodgy json
-    with testutils.patch_request("app.external.rawls", "get", status_code = 200, json={"spacework" : {"wOrKsPaCeId" : "uuid"}}):
+    with testutils.patch_request("app.external.rawls", "get", status_code = 200, json={"spacework" : {"wOrKsPaCeId" : "uuid", "googleProject": "proj"}}):
         with pytest.raises(KeyError):
-            rawls.get_workspace_uuid("a", "a", "a")
+            rawls.get_workspace_uuid_and_project("a", "a", "a")
 
     # rawls returns ok with good json, parse it out
-    with testutils.patch_request("app.external.rawls", "get", status_code = 200, json={"workspace" : {"workspaceId" : "uuid"}}):
-        assert rawls.get_workspace_uuid("a", "a", "a") == "uuid"
+    with testutils.patch_request("app.external.rawls", "get", status_code = 200, json={"workspace" : {"workspaceId" : "the-uuid", "googleProject": "proj"}}):
+        assert rawls.get_workspace_uuid_and_project("a", "a", "a") == {"uuid": "the-uuid", "googleProject": "proj"}
 
 
 def test_check_workspace_iam_action():

--- a/app/tests/test_rawls.py
+++ b/app/tests/test_rawls.py
@@ -3,7 +3,7 @@ import pytest
 from app.tests import testutils
 from app.util import exceptions
 from app.external import rawls
-
+from app.external.rawls import RawlsWorkspaceResponse
 
 def test_get_workspace_uuid():
     # rawls returns non-OK response
@@ -18,7 +18,7 @@ def test_get_workspace_uuid():
 
     # rawls returns ok with good json, parse it out
     with testutils.patch_request("app.external.rawls", "get", status_code = 200, json={"workspace" : {"workspaceId" : "the-uuid", "googleProject": "proj"}}):
-        assert rawls.get_workspace_uuid_and_project("a", "a", "a") == {"uuid": "the-uuid", "googleProject": "proj"}
+        assert rawls.get_workspace_uuid_and_project("a", "a", "a") == RawlsWorkspaceResponse("the-uuid", "proj")
 
 
 def test_check_workspace_iam_action():

--- a/app/tests/test_status.py
+++ b/app/tests/test_status.py
@@ -46,7 +46,7 @@ def test_get_all_import_status(fake_import, client):
 def test_get_all_running_when_none(client):
     # poke in one import that's in the Done state
     with db.session_ctx() as sess:
-        new_import = Import("namespace", "name", "uuid", "hello@me.com", "http://path", "pfb")
+        new_import = Import("namespace", "name", "uuid", "project", "hello@me.com", "http://path", "pfb")
         new_import.status = ImportStatus.Done
         sess.add(new_import)
         sess.commit()

--- a/app/tests/test_translate.py
+++ b/app/tests/test_translate.py
@@ -169,7 +169,7 @@ def test_golden_path_parquet(fake_import_parquet, fake_publish_rawls, client):
 @pytest.mark.usefixtures("good_http_pfb", "good_gcs_dest", "incoming_valid_pubsub")
 def test_publish_rawls_is_upsert_passed_on(is_upsert, fake_publish_rawls, client):
     """is_upsert value from the database is sent along to Rawls in the pubsub message."""
-    test_import = model.Import("bb", "bb", "uuid", "bb@bb.bb", "gs://bb/bb", "pfb", is_upsert=is_upsert)
+    test_import = model.Import("bb", "bb", "uuid", "project", "bb@bb.bb", "gs://bb/bb", "pfb", is_upsert=is_upsert)
 
     with db.session_ctx() as sess:
         sess.add(test_import)

--- a/app/tests/test_user_auth.py
+++ b/app/tests/test_user_auth.py
@@ -6,7 +6,9 @@ from werkzeug.test import EnvironBuilder
 
 import app.external.rawls
 from app.auth import user_auth
+from app.external.rawls import RawlsWorkspaceResponse
 from app.util import exceptions
+
 
 
 def fake_authtoken_request(headers: dict) -> flask.Request:
@@ -47,28 +49,28 @@ def test_workspace_uuid():
             mock_rawls_getaction.assert_not_called()
 
     # rawls returns workspace id, action is "read", no need to do auth check
-    with mock.patch.object(app.external.rawls, "get_workspace_uuid_and_project", return_value ={"uuid": "the-uuid", "googleProject": "proj"}):
+    with mock.patch.object(app.external.rawls, "get_workspace_uuid_and_project", return_value = RawlsWorkspaceResponse("the-uuid", "proj")):
         with mock.patch.object(app.external.rawls, "check_workspace_iam_action") as mock_rawls_getaction:
-            assert user_auth.workspace_uuid_and_project_with_auth("wsns", "wsn", "bearer", "read") == {"uuid": "the-uuid", "googleProject": "proj"}
+            assert user_auth.workspace_uuid_and_project_with_auth("wsns", "wsn", "bearer", "read") == RawlsWorkspaceResponse("the-uuid", "proj")
             mock_rawls_getaction.assert_not_called()
 
     # rawls returns workspace id, action is write, auth check called, returns non-OK status
-    with mock.patch.object(app.external.rawls, "get_workspace_uuid_and_project", return_value ={"uuid": "the-uuid", "googleProject": "proj"}):
+    with mock.patch.object(app.external.rawls, "get_workspace_uuid_and_project", return_value = RawlsWorkspaceResponse("the-uuid", "proj")):
         with mock.patch.object(app.external.rawls, "check_workspace_iam_action", side_effect = exceptions.ISvcException("bork", 500)) as mock_rawls_getaction:
             with pytest.raises(exceptions.ISvcException):
                 user_auth.workspace_uuid_and_project_with_auth("wsns", "wsn", "bearer", "write")
             mock_rawls_getaction.assert_called_once()
 
     # rawls returns workspace id, action is write, auth check called, returns false: you can't do this action
-    with mock.patch.object(app.external.rawls, "get_workspace_uuid_and_project", return_value ={"uuid": "the-uuid", "googleProject": "proj"}):
+    with mock.patch.object(app.external.rawls, "get_workspace_uuid_and_project", return_value = RawlsWorkspaceResponse("the-uuid", "proj")):
         with mock.patch.object(app.external.rawls, "check_workspace_iam_action", return_value = False) as mock_rawls_getaction:
             with pytest.raises(exceptions.AuthorizationException):
                 user_auth.workspace_uuid_and_project_with_auth("wsns", "wsn", "bearer", "write")
             mock_rawls_getaction.assert_called_once()
 
     # rawls returns workspace id, action is write, auth check called, returns true: hooray!
-    with mock.patch.object(app.external.rawls, "get_workspace_uuid_and_project", return_value ={"uuid": "the-uuid", "googleProject": "proj"}):
+    with mock.patch.object(app.external.rawls, "get_workspace_uuid_and_project", return_value = RawlsWorkspaceResponse("the-uuid", "proj")):
         with mock.patch.object(app.external.rawls, "check_workspace_iam_action", return_value = True) as mock_rawls_getaction:
-            assert user_auth.workspace_uuid_and_project_with_auth("wsns", "wsn", "bearer", "write") == {"uuid": "the-uuid", "googleProject": "proj"}
+            assert user_auth.workspace_uuid_and_project_with_auth("wsns", "wsn", "bearer", "write") == RawlsWorkspaceResponse("the-uuid", "proj")
             mock_rawls_getaction.assert_called_once()
 

--- a/app/tests/test_user_auth.py
+++ b/app/tests/test_user_auth.py
@@ -33,42 +33,42 @@ def test_extract_auth_token():
 
 def test_workspace_uuid():
     # rawls returns an exception for the workspace, exception raised, auth check not called
-    with mock.patch.object(app.external.rawls, "get_workspace_uuid", side_effect = exceptions.ISvcException("bork", 400)):
+    with mock.patch.object(app.external.rawls, "get_workspace_uuid_and_project", side_effect = exceptions.ISvcException("bork", 400)):
         with mock.patch.object(app.external.rawls, "check_workspace_iam_action") as mock_rawls_getaction:
             with pytest.raises(exceptions.ISvcException):
-                user_auth.workspace_uuid_with_auth("wsns", "wsn", "bearer", "read")
+                user_auth.workspace_uuid_and_project_with_auth("wsns", "wsn", "bearer", "read")
             mock_rawls_getaction.assert_not_called()
 
     # rawls returns no workspace id in the body, KeyError reported, auth check not called
-    with mock.patch.object(app.external.rawls, "get_workspace_uuid", side_effect = KeyError):
+    with mock.patch.object(app.external.rawls, "get_workspace_uuid_and_project", side_effect = KeyError):
         with mock.patch.object(app.external.rawls, "check_workspace_iam_action") as mock_rawls_getaction:
             with pytest.raises(KeyError):
-                user_auth.workspace_uuid_with_auth("wsns", "wsn", "bearer", "read")
+                user_auth.workspace_uuid_and_project_with_auth("wsns", "wsn", "bearer", "read")
             mock_rawls_getaction.assert_not_called()
 
     # rawls returns workspace id, action is "read", no need to do auth check
-    with mock.patch.object(app.external.rawls, "get_workspace_uuid", return_value ="uuid"):
+    with mock.patch.object(app.external.rawls, "get_workspace_uuid_and_project", return_value ={"uuid": "the-uuid", "googleProject": "proj"}):
         with mock.patch.object(app.external.rawls, "check_workspace_iam_action") as mock_rawls_getaction:
-            assert user_auth.workspace_uuid_with_auth("wsns", "wsn", "bearer", "read") == "uuid"
+            assert user_auth.workspace_uuid_and_project_with_auth("wsns", "wsn", "bearer", "read") == {"uuid": "the-uuid", "googleProject": "proj"}
             mock_rawls_getaction.assert_not_called()
 
     # rawls returns workspace id, action is write, auth check called, returns non-OK status
-    with mock.patch.object(app.external.rawls, "get_workspace_uuid", return_value ="uuid"):
+    with mock.patch.object(app.external.rawls, "get_workspace_uuid_and_project", return_value ={"uuid": "the-uuid", "googleProject": "proj"}):
         with mock.patch.object(app.external.rawls, "check_workspace_iam_action", side_effect = exceptions.ISvcException("bork", 500)) as mock_rawls_getaction:
             with pytest.raises(exceptions.ISvcException):
-                user_auth.workspace_uuid_with_auth("wsns", "wsn", "bearer", "write")
+                user_auth.workspace_uuid_and_project_with_auth("wsns", "wsn", "bearer", "write")
             mock_rawls_getaction.assert_called_once()
 
     # rawls returns workspace id, action is write, auth check called, returns false: you can't do this action
-    with mock.patch.object(app.external.rawls, "get_workspace_uuid", return_value ="uuid"):
+    with mock.patch.object(app.external.rawls, "get_workspace_uuid_and_project", return_value ={"uuid": "the-uuid", "googleProject": "proj"}):
         with mock.patch.object(app.external.rawls, "check_workspace_iam_action", return_value = False) as mock_rawls_getaction:
             with pytest.raises(exceptions.AuthorizationException):
-                user_auth.workspace_uuid_with_auth("wsns", "wsn", "bearer", "write")
+                user_auth.workspace_uuid_and_project_with_auth("wsns", "wsn", "bearer", "write")
             mock_rawls_getaction.assert_called_once()
 
     # rawls returns workspace id, action is write, auth check called, returns true: hooray!
-    with mock.patch.object(app.external.rawls, "get_workspace_uuid", return_value ="uuid"):
+    with mock.patch.object(app.external.rawls, "get_workspace_uuid_and_project", return_value ={"uuid": "the-uuid", "googleProject": "proj"}):
         with mock.patch.object(app.external.rawls, "check_workspace_iam_action", return_value = True) as mock_rawls_getaction:
-            assert user_auth.workspace_uuid_with_auth("wsns", "wsn", "bearer", "write") == "uuid"
+            assert user_auth.workspace_uuid_and_project_with_auth("wsns", "wsn", "bearer", "write") == {"uuid": "the-uuid", "googleProject": "proj"}
             mock_rawls_getaction.assert_called_once()
 


### PR DESCRIPTION
part of AS-1037 but does not complete that ticket.

This PR adds a new `workspace_google_project` column/property to the `Import` object, and persists the workspace's googleProject (as returned by Rawls) for each new import.

This is a prereq for later work, in which we will need to get the user's pet inside that project and use that project for reading into GCS.

Because we do not yet have automatic DB schema migration for import service (AS-184), this PR will require manual handholding to alter the db schema in each env: 
```
ALTER TABLE imports ADD workspace_google_project varchar(30) NOT NULL default '' AFTER workspace_uuid;
```