### PR TITLE
include filetype when listing/getting jobs [AS-945]

### DIFF
--- a/app/db/model.py
+++ b/app/db/model.py
@@ -88,9 +88,10 @@ ModelDefinition = Dict[str, Type[fields.Raw]]
 # Note: this should really be a namedtuple but for https://github.com/noirbizarre/flask-restplus/issues/364
 # This is an easy fix in flask-restx if we decide to go this route.
 class ImportStatusResponse:
-    def __init__(self, jobId: str, status: str, message: Optional[str]):
+    def __init__(self, jobId: str, status: str, filetype: str, message: Optional[str]):
         self.jobId = jobId
         self.status = status
+        self.filetype = filetype
         self.message = message
 
     @classmethod
@@ -98,6 +99,7 @@ class ImportStatusResponse:
         return {
             "jobId": fields.String,
             "status": fields.String,
+            "filetype": fields.String,
             "message": fields.String }
 
 
@@ -164,4 +166,4 @@ class Import(ImportServiceTable, EqMixin, Base):
         self.status = ImportStatus.Error
 
     def to_status_response(self) -> ImportStatusResponse:
-        return ImportStatusResponse(self.id, self.status.name, self.error_message)
+        return ImportStatusResponse(self.id, self.status.name, self.filetype, self.error_message)

--- a/app/status.py
+++ b/app/status.py
@@ -92,4 +92,4 @@ def external_update_status(msg: Dict[str, str]) -> model.ImportStatusResponse:
         logging.warning(f"Failed to update status for import {import_id}: wanted {current_status}->{new_status}, actually {imp.status}.")
 
     # This goes back to Pub/Sub, nobody reads it
-    return model.ImportStatusResponse(import_id, new_status.name, None)
+    return model.ImportStatusResponse(import_id, new_status.name, imp.filetype, None)

--- a/app/tests/test_status.py
+++ b/app/tests/test_status.py
@@ -19,7 +19,7 @@ def test_get_import_status(client):
 
     resp = client.get(f'/namespace/name/imports/{import_id}', headers=good_headers)
     assert resp.status_code == 200
-    assert resp.json == {'jobId': import_id, 'status': ImportStatus.Pending.name}
+    assert resp.json == {'jobId': import_id, 'filetype': 'pfb', 'status': ImportStatus.Pending.name}
 
 
 @pytest.mark.usefixtures("sam_valid_user", "user_has_ws_access", "pubsub_publish", "pubsub_fake_env")
@@ -39,7 +39,7 @@ def test_get_all_import_status(fake_import, client):
 
     resp = client.get('/aa/aa/imports', headers=good_headers)
     assert resp.status_code == 200
-    assert resp.json == [{"jobId": fake_import.id, "status": ImportStatus.Error.name, 'message': "broke"}]
+    assert resp.json == [{"jobId": fake_import.id, "filetype": "pfb", "status": ImportStatus.Error.name, 'message': "broke"}]
 
 
 @pytest.mark.usefixtures("sam_valid_user", "user_has_ws_access", "pubsub_publish", "pubsub_fake_env")
@@ -64,7 +64,7 @@ def test_get_all_running_with_one(client):
 
     resp = client.get('/namespace/name/imports?running_only', headers=good_headers)
     assert resp.status_code == 200
-    assert resp.json == [{"jobId": import_id, "status": ImportStatus.Pending.name}]
+    assert resp.json == [{"jobId": import_id, "filetype": "pfb", "status": ImportStatus.Pending.name}]
 
 
 @pytest.mark.usefixtures("incoming_valid_pubsub")

--- a/app/translate.py
+++ b/app/translate.py
@@ -101,7 +101,7 @@ def handle(msg: Dict[str, str]) -> ImportStatusResponse:
         "isUpsert": str(import_details.is_upsert)
     })
 
-    return ImportStatusResponse(import_id, ImportStatus.ReadyForUpsert.name, None)
+    return ImportStatusResponse(import_id, ImportStatus.ReadyForUpsert.name, import_details.filetype, None)
 
 
 def _stream_translate(import_id: str, source: IO, dest: IO, file_type: str, translator: Translator) -> None:


### PR DESCRIPTION
response payload change from
```
  {
    "jobId": "string",
    "status": "string",
    "message": "string"
  }
```
to
```
  {
    "jobId": "string",
    "filetype": "string",
    "status": "string",
    "message": "string"
  }
```