### PR TITLE
timestamp, source snapshotid, tdr namespace for all attributes [AS-1041]

### DIFF
--- a/app/tests/test_tdr_manifest_to_rawls.py
+++ b/app/tests/test_tdr_manifest_to_rawls.py
@@ -29,13 +29,13 @@ def test_translate_data_frame():
     assert len(entities) == 3
     assert entities[0].name == 'a'
     assert entities[0].entityType == 'unittest'
-    assert entities[0].operations == [AddUpdateAttribute('datarepo_row_id', 'a'), AddUpdateAttribute('one', 1), AddUpdateAttribute('two', 'foo')]
+    assert entities[0].operations == [AddUpdateAttribute('tdr:datarepo_row_id', 'a'), AddUpdateAttribute('tdr:one', 1), AddUpdateAttribute('tdr:two', 'foo')]
     assert entities[1].name == 'b'
     assert entities[1].entityType == 'unittest'
-    assert entities[1].operations == [AddUpdateAttribute('datarepo_row_id', 'b'), AddUpdateAttribute('one', 2), AddUpdateAttribute('two', 'bar')]
+    assert entities[1].operations == [AddUpdateAttribute('tdr:datarepo_row_id', 'b'), AddUpdateAttribute('tdr:one', 2), AddUpdateAttribute('tdr:two', 'bar')]
     assert entities[2].name == 'c'
     assert entities[2].entityType == 'unittest'
-    assert entities[2].operations == [AddUpdateAttribute('datarepo_row_id', 'c'), AddUpdateAttribute('one', 3), AddUpdateAttribute('two', 'baz')]
+    assert entities[2].operations == [AddUpdateAttribute('tdr:datarepo_row_id', 'c'), AddUpdateAttribute('tdr:one', 3), AddUpdateAttribute('tdr:two', 'baz')]
 
 def get_fake_parquet_translator() -> ParquetTranslator:
     fake_table = TDRTable('unittest', 'datarepo_row_id', [], {})
@@ -64,13 +64,13 @@ def test_translate_parquet_file_to_entities():
     assert len(entities) == 3
     assert entities[0].name == 'a'
     assert entities[0].entityType == 'unittest'
-    assert entities[0].operations == [AddUpdateAttribute('datarepo_row_id', 'a'), AddUpdateAttribute('one', 1), AddUpdateAttribute('two', 'foo')]
+    assert entities[0].operations == [AddUpdateAttribute('tdr:datarepo_row_id', 'a'), AddUpdateAttribute('tdr:one', 1), AddUpdateAttribute('tdr:two', 'foo')]
     assert entities[1].name == 'b'
     assert entities[1].entityType == 'unittest'
-    assert entities[1].operations == [AddUpdateAttribute('datarepo_row_id', 'b'), AddUpdateAttribute('one', 2), AddUpdateAttribute('two', 'bar')]
+    assert entities[1].operations == [AddUpdateAttribute('tdr:datarepo_row_id', 'b'), AddUpdateAttribute('tdr:one', 2), AddUpdateAttribute('tdr:two', 'bar')]
     assert entities[2].name == 'c'
     assert entities[2].entityType == 'unittest'
-    assert entities[2].operations == [AddUpdateAttribute('datarepo_row_id', 'c'), AddUpdateAttribute('one', 3), AddUpdateAttribute('two', 'baz')]
+    assert entities[2].operations == [AddUpdateAttribute('tdr:datarepo_row_id', 'c'), AddUpdateAttribute('tdr:one', 3), AddUpdateAttribute('tdr:two', 'baz')]
 
 # file-like to ([Entity])
 def test_translate_parquet_file_with_missing_pk():
@@ -90,10 +90,10 @@ def test_translate_parquet_file_with_missing_pk():
     assert len(entities) == 2
     assert entities[0].name == 'first'
     assert entities[0].entityType == 'unittest'
-    assert entities[0].operations == [AddUpdateAttribute('datarepo_row_id', 'a'), AddUpdateAttribute('custompk', 'first'), AddUpdateAttribute('two', 'foo')]
+    assert entities[0].operations == [AddUpdateAttribute('tdr:datarepo_row_id', 'a'), AddUpdateAttribute('tdr:custompk', 'first'), AddUpdateAttribute('tdr:two', 'foo')]
     assert entities[1].name == 'third'
     assert entities[1].entityType == 'unittest'
-    assert entities[1].operations == [AddUpdateAttribute('datarepo_row_id', 'c'), AddUpdateAttribute('custompk', 'third'), AddUpdateAttribute('two', 'baz')]
+    assert entities[1].operations == [AddUpdateAttribute('tdr:datarepo_row_id', 'c'), AddUpdateAttribute('tdr:custompk', 'third'), AddUpdateAttribute('tdr:two', 'baz')]
 
 # file-like to ([Entity])
 def test_translate_parquet_file_with_array_attrs():
@@ -117,55 +117,55 @@ def test_translate_parquet_file_with_array_attrs():
     assert len(entities) == 3
     assert entities[0].name == 'first'
     assert entities[0].entityType == 'unittest'
-    assert entities[0].operations == [AddUpdateAttribute('datarepo_row_id', 'a'), AddUpdateAttribute('custompk', 'first'),
-        RemoveAttribute('arrayattr'), CreateAttributeValueList('arrayattr'),
-        AddListMember('arrayattr', 'Philip'), AddListMember('arrayattr', 'Glass')
+    assert entities[0].operations == [AddUpdateAttribute('tdr:datarepo_row_id', 'a'), AddUpdateAttribute('tdr:custompk', 'first'),
+        RemoveAttribute('tdr:arrayattr'), CreateAttributeValueList('tdr:arrayattr'),
+        AddListMember('tdr:arrayattr', 'Philip'), AddListMember('tdr:arrayattr', 'Glass')
     ]
     assert entities[1].name == 'second'
     assert entities[1].entityType == 'unittest'
-    assert entities[1].operations == [AddUpdateAttribute('datarepo_row_id', 'b'), AddUpdateAttribute('custompk', 'second'),
-        RemoveAttribute('arrayattr'), CreateAttributeValueList('arrayattr'),
-        AddListMember('arrayattr', 'Wolfgang'), AddListMember('arrayattr', 'Amadeus'), AddListMember('arrayattr', 'Mozart')
+    assert entities[1].operations == [AddUpdateAttribute('tdr:datarepo_row_id', 'b'), AddUpdateAttribute('tdr:custompk', 'second'),
+        RemoveAttribute('tdr:arrayattr'), CreateAttributeValueList('tdr:arrayattr'),
+        AddListMember('tdr:arrayattr', 'Wolfgang'), AddListMember('tdr:arrayattr', 'Amadeus'), AddListMember('tdr:arrayattr', 'Mozart')
     ]
     assert entities[2].name == 'third'
     assert entities[2].entityType == 'unittest'
-    assert entities[2].operations == [AddUpdateAttribute('datarepo_row_id', 'c'), AddUpdateAttribute('custompk', 'third'),
-        RemoveAttribute('arrayattr'), CreateAttributeValueList('arrayattr'),
-        AddListMember('arrayattr', 'Dmitri'), AddListMember('arrayattr', 'Shostakovich')
+    assert entities[2].operations == [AddUpdateAttribute('tdr:datarepo_row_id', 'c'), AddUpdateAttribute('tdr:custompk', 'third'),
+        RemoveAttribute('tdr:arrayattr'), CreateAttributeValueList('tdr:arrayattr'),
+        AddListMember('tdr:arrayattr', 'Dmitri'), AddListMember('tdr:arrayattr', 'Shostakovich')
     ]
 
 # KVP to AttributeOperation
 def test_translate_parquet_attr():
     translator = get_fake_parquet_translator()
     # translator has entityType 'unittest', so 'unittest_id' should be namespaced
-    assert translator.translate_parquet_attr('unittest_id', 123) == [AddUpdateAttribute('pfb:unittest_id', 123)]
-    assert translator.translate_parquet_attr('somethingelse', 123) == [AddUpdateAttribute('somethingelse', 123)]
-    assert translator.translate_parquet_attr('datarepo_row_id', 123) == [AddUpdateAttribute('datarepo_row_id', 123)]
+    assert translator.translate_parquet_attr('unittest_id', 123) == [AddUpdateAttribute('tdr:unittest_id', 123)]
+    assert translator.translate_parquet_attr('somethingelse', 123) == [AddUpdateAttribute('tdr:somethingelse', 123)]
+    assert translator.translate_parquet_attr('datarepo_row_id', 123) == [AddUpdateAttribute('tdr:datarepo_row_id', 123)]
 
-    assert translator.translate_parquet_attr('foo', True) == [AddUpdateAttribute('foo', True)]
-    assert translator.translate_parquet_attr('foo', 'astring') == [AddUpdateAttribute('foo', 'astring')]
-    assert translator.translate_parquet_attr('foo', 123) == [AddUpdateAttribute('foo', 123)]
-    assert translator.translate_parquet_attr('foo', 456.78) == [AddUpdateAttribute('foo', 456.78)]
+    assert translator.translate_parquet_attr('foo', True) == [AddUpdateAttribute('tdr:foo', True)]
+    assert translator.translate_parquet_attr('foo', 'astring') == [AddUpdateAttribute('tdr:foo', 'astring')]
+    assert translator.translate_parquet_attr('foo', 123) == [AddUpdateAttribute('tdr:foo', 123)]
+    assert translator.translate_parquet_attr('foo', 456.78) == [AddUpdateAttribute('tdr:foo', 456.78)]
 
     curtime = datetime.now()
-    assert translator.translate_parquet_attr('foo', curtime) == [AddUpdateAttribute('foo', str(curtime))]
+    assert translator.translate_parquet_attr('foo', curtime) == [AddUpdateAttribute('tdr:foo', str(curtime))]
 
     arr = ['a', 'b', 'c']
-    assert translator.translate_parquet_attr('foo', arr) == [AddUpdateAttribute('foo', str(arr))]
+    assert translator.translate_parquet_attr('foo', arr) == [AddUpdateAttribute('tdr:foo', str(arr))]
 
 def test_translate_parquet_attr_arrays():
     translator = get_fake_parquet_translator()
 
     assert translator.translate_parquet_attr('myarray', np.array([1, 2, 3])) == [
-        RemoveAttribute('myarray'), CreateAttributeValueList('myarray'),
-        AddListMember('myarray', 1), AddListMember('myarray', 2), AddListMember('myarray', 3)]
+        RemoveAttribute('tdr:myarray'), CreateAttributeValueList('tdr:myarray'),
+        AddListMember('tdr:myarray', 1), AddListMember('tdr:myarray', 2), AddListMember('tdr:myarray', 3)]
 
     assert translator.translate_parquet_attr('myarray', np.array(['foo', 'bar'])) == [
-        RemoveAttribute('myarray'), CreateAttributeValueList('myarray'),
-        AddListMember('myarray', 'foo'), AddListMember('myarray', 'bar')]
+        RemoveAttribute('tdr:myarray'), CreateAttributeValueList('tdr:myarray'),
+        AddListMember('tdr:myarray', 'foo'), AddListMember('tdr:myarray', 'bar')]
 
     time1 = datetime.now()
     time2 = datetime.now()
     assert translator.translate_parquet_attr('myarray', np.array([time1, time2])) == [
-        RemoveAttribute('myarray'), CreateAttributeValueList('myarray'),
-        AddListMember('myarray', str(time1)), AddListMember('myarray', str(time2))]
+        RemoveAttribute('tdr:myarray'), CreateAttributeValueList('tdr:myarray'),
+        AddListMember('tdr:myarray', str(time1)), AddListMember('tdr:myarray', str(time2))]

--- a/app/translators/tdr_manifest_to_rawls.py
+++ b/app/translators/tdr_manifest_to_rawls.py
@@ -32,30 +32,28 @@ class TDRManifestToRawls(Translator):
 
     def translate(self, import_details: Import, file_like: IO) -> Iterator[Entity]:
         logging.info(f'{import_details.id} executing a TDRManifestToRawls translation for {import_details.filetype}: {file_like}')
-        tables = self.get_tables(file_like)
-        return itertools.chain(*self.translate_tables(import_details, tables))
-
-    @classmethod
-    def get_tables(cls, file_like: IO) -> List[TDRTable]:
-        # read and parse entire manifest file
         jso = json.load(file_like)
-        return TDRManifestParser(jso).get_tables()
+        parsed_manifest = TDRManifestParser(jso)
+        source_snapshot_id = parsed_manifest.get_snapshot_id()
+        tables = parsed_manifest.get_tables(file_like)
+        return itertools.chain(*self.translate_tables(import_details, source_snapshot_id, tables))
 
     @classmethod
-    def translate_tables(cls, import_details: Import, tables: List[TDRTable]) -> Iterator[Iterator[Entity]]:
+    def translate_tables(cls, import_details: Import, source_snapshot_id: str, tables: List[TDRTable]) -> Iterator[Iterator[Entity]]:
         """Converts a list of TDR tables, each of which contain urls to parquet files, to an iterator of Entity objects."""
         for t in tables:
             for f in t.parquet_files:
-                pt = ParquetTranslator(t, f, import_details)
+                pt = ParquetTranslator(t, f, import_details, source_snapshot_id)
                 yield pt.translate()
 
 class ParquetTranslator:
-    def __init__(self, table: TDRTable, filelocation: str, import_details: Import):
+    def __init__(self, table: TDRTable, filelocation: str, import_details: Import, source_snapshot_id: str):
         """Translator for Parquet files coming from a TDR manifest."""
         self.table = table
         self.import_details = import_details
         self.filelocation = filelocation
         self.file_nickname = os.path.split(filelocation)[1]
+        self.source_snapshot_id = source_snapshot_id
 
     def translate(self) -> Iterator[Entity]:
         """Converts a parquet file, represented as a url, to an iterator of Entity objects."""
@@ -104,13 +102,11 @@ class ParquetTranslator:
         """Convert a single row of a pandas dataframe - assumed from a Parquet file - to an Entity."""
         # annotate row with the timestamp of the import
         tsattr = self.translate_parquet_attr('timestamp', self.import_details.submit_time.isoformat(), 'import')
-
-        # TODO AS-1041: annotate row with the snapshotid from TDR
-        # we don't currently have the snapshotid, you'll need to find a way to pass that info down to here
-        # the snapshotid is available from TDRManifestParser.get_snapshot_id (which isn't available here)
+        # annotate row with the snapshotid from TDR
+        sourceidattr = self.translate_parquet_attr('snapshot_id', self.source_snapshot_id, 'import')
 
         all_attr_ops = [self.translate_parquet_attr(colname, row[colname]) for colname in column_names]
-        return list(itertools.chain(*all_attr_ops, tsattr))
+        return list(itertools.chain(*all_attr_ops, sourceidattr, tsattr))
 
     def translate_parquet_attr(self, name: str, value, namespace: str = "tdr") -> List[AttributeOperation]:
         """Convert a single cell of a pandas dataframe - assumed from a Parquet file - to an AddUpdateAttribute."""

--- a/app/translators/tdr_manifest_to_rawls.py
+++ b/app/translators/tdr_manifest_to_rawls.py
@@ -35,7 +35,7 @@ class TDRManifestToRawls(Translator):
         jso = json.load(file_like)
         parsed_manifest = TDRManifestParser(jso)
         source_snapshot_id = parsed_manifest.get_snapshot_id()
-        tables = parsed_manifest.get_tables(file_like)
+        tables = parsed_manifest.get_tables()
         return itertools.chain(*self.translate_tables(import_details, source_snapshot_id, tables))
 
     @classmethod

--- a/app/translators/tdr_manifest_to_rawls.py
+++ b/app/translators/tdr_manifest_to_rawls.py
@@ -113,14 +113,9 @@ class ParquetTranslator:
 
     def translate_parquet_attr(self, name: str, value) -> List[AttributeOperation]:
         """Convert a single cell of a pandas dataframe - assumed from a Parquet file - to an AddUpdateAttribute."""
-        # {entity_type}_id is a reserved name. If the import contains a column named thusly,
-        # move that column into the "import:" namespace to avoid conflicts
-        if (name != f'{self.table.name}_id'):
-            usable_name = name
-        else:
-            # TODO AS-1040: need to enable new namespaces in Rawls. As of this writing, Rawls only supports 'pfb', 'library', and 'tag'
-            # in addition to the default namespace. For now, use the pfb namespace just so we can see it working
-            usable_name = f'pfb:{name}'
+        # add all attributes to the "tdr:" namespace to avoid  conflicts,
+        # e.g. with {entity_type}_id which is a is a reserved name in Rawls.
+        usable_name = f'tdr:{name}'
 
         # TODO: AS-1038 detect/create references
         is_reference = False


### PR DESCRIPTION
depends on broadinstitute/rawls#1596

Three changes in this PR:
* for TDR import-by-copy, create all imported attributes inside the `tdr:` namespace. This avoids conflicts with reserved attribute names in Rawls ("name", "entityType", and "${entityType}_id". The last of those is the most common conflict.
* always add an "import:timestamp" attribute to each row, containing the timestamp of the import request
* always add an "import:snapshot_id" attribute to each row, containing the uuid of the snapshot from which we are importing