### PR TITLE
re-enable golden path TDR import unit test [AS-1075]

### DIFF
--- a/app/tests/test_translate.py
+++ b/app/tests/test_translate.py
@@ -15,6 +15,9 @@ from app.server import requestutils
 from app.tests import testutils
 from app.translators import Translator
 
+# necessary to set this env var for unit tests; at runtime this is set by app.yaml
+# if we don't set it here, assertions that compare gs:// paths can fail with
+# an error where expected is "unittest-allowed-bucket" but actual is "None"
 os.environ.setdefault("BATCH_UPSERT_BUCKET", "unittest-allowed-bucket")
 
 class StreamyNoOpTranslator(Translator):

--- a/app/tests/test_translate.py
+++ b/app/tests/test_translate.py
@@ -14,6 +14,7 @@ from app.server import requestutils
 from app.tests import testutils
 from app.translators import Translator
 
+os.environ.setdefault("BATCH_UPSERT_BUCKET", "unittest-allowed-bucket")
 
 class StreamyNoOpTranslator(Translator):
     """Well-behaved no-op translator: does nothing, while streaming"""


### PR DESCRIPTION
AS-1075

This re-enables the "golden path" unit test for TDR import-by-copy. That test needed some extra mocking magic, which I've now implemented inside this PR.