### PR TITLE
additional logging around permission-sync [AJ-111]

### DIFF
--- a/app/new_import.py
+++ b/app/new_import.py
@@ -37,7 +37,7 @@ def handle(request: flask.Request, ws_ns: str, ws_name: str) -> model.ImportStat
         except exceptions.AuthorizationException as ae:
             # rewrite the auth error to something nicer
             raise exceptions.AuthorizationException("You must be a workspace Owner or a Writer with Can-Share to " +
-            f"perform this import. Original error message: ${ae.message}")
+            f"perform this import. Original error message: {ae.message}")
     # END additional check specific to tdrexport
 
     # and validate the input's path

--- a/app/status.py
+++ b/app/status.py
@@ -1,5 +1,6 @@
 import flask
 import logging
+import traceback
 from sqlalchemy.orm.exc import NoResultFound
 from typing import Dict, List
 
@@ -93,6 +94,7 @@ def external_update_status(msg: Dict[str, str]) -> model.ImportStatusResponse:
                     sync.sync_permissions_if_necessary(imp, new_status)
                 except Exception as err:
                     failed_sync = True
+                    logging.error(f"Error during permission syncing for import {import_id}: {traceback.format_exc()}")
                     imp.write_error(f"All data imported successfully, but failed to synchronize permissions for import {import_id}: {err}")
                 if not failed_sync:
                     model.Import.update_status_exclusively(import_id, imp.status, new_status, sess)

--- a/app/translators/sync_permissions.py
+++ b/app/translators/sync_permissions.py
@@ -31,6 +31,7 @@ def sync_permissions(import_details: Import, snapshot_id: str):
 
     # call policy group emails and add them as readers to the snapshot
     policy_group_emails: List[str] = get_policy_group_emails(import_details.workspace_uuid, pet_token)
+    logging.info(f"Found {len(policy_group_emails)} policy groups to sync for import {import_details.id} for snapshot {snapshot_id}")
     for policy_group_email in policy_group_emails:
         tdr.add_snapshot_policy_member(snapshot_id, tdr.READER_POLICY_NAME, policy_group_email, pet_token)
 


### PR DESCRIPTION
In my work to write integration tests (broadinstitute/firecloud-orchestration#916), I'm seeing some test failures that are difficult to debug. Here, I add a couple more logging statements to try to track down what's happening inside Import Service to cause failed imports during the permission-sync step.