### PR TITLE
workspace namespace, name column lengths [AJ-306]

### DIFF
--- a/app/db/model.py
+++ b/app/db/model.py
@@ -107,8 +107,8 @@ class Import(ImportServiceTable, EqMixin, Base):
     __tablename__ = 'imports'
 
     id = Column(String(36), primary_key=True)
-    workspace_name = Column(String(100), nullable=False)
-    workspace_namespace = Column(String(100), nullable=False)
+    workspace_name = Column(String(254), nullable=False)
+    workspace_namespace = Column(String(254), nullable=False)
     workspace_uuid = Column(String(36), nullable=False)
     workspace_google_project = Column(String(30), nullable=False)
     submitter = Column(String(100), nullable=False)

--- a/app/tests/test_tdr_manifest_to_rawls.py
+++ b/app/tests/test_tdr_manifest_to_rawls.py
@@ -40,13 +40,13 @@ def test_translate_data_frame():
     assert len(entities) == 3
     assert entities[0].name == 'a'
     assert entities[0].entityType == 'unittest'
-    assert entities[0].operations == [AddUpdateAttribute('tdr:datarepo_row_id', 'a'), AddUpdateAttribute('tdr:one', 1), AddUpdateAttribute('tdr:two', 'foo'), _import_sourceid(random_snapshot_id), _import_timestamp(now)]
+    assert entities[0].operations == [AddUpdateAttribute('datarepo_row_id', 'a'), AddUpdateAttribute('one', 1), AddUpdateAttribute('two', 'foo'), _import_sourceid(random_snapshot_id), _import_timestamp(now)]
     assert entities[1].name == 'b'
     assert entities[1].entityType == 'unittest'
-    assert entities[1].operations == [AddUpdateAttribute('tdr:datarepo_row_id', 'b'), AddUpdateAttribute('tdr:one', 2), AddUpdateAttribute('tdr:two', 'bar'), _import_sourceid(random_snapshot_id), _import_timestamp(now)]
+    assert entities[1].operations == [AddUpdateAttribute('datarepo_row_id', 'b'), AddUpdateAttribute('one', 2), AddUpdateAttribute('two', 'bar'), _import_sourceid(random_snapshot_id), _import_timestamp(now)]
     assert entities[2].name == 'c'
     assert entities[2].entityType == 'unittest'
-    assert entities[2].operations == [AddUpdateAttribute('tdr:datarepo_row_id', 'c'), AddUpdateAttribute('tdr:one', 3), AddUpdateAttribute('tdr:two', 'baz'), _import_sourceid(random_snapshot_id), _import_timestamp(now)]
+    assert entities[2].operations == [AddUpdateAttribute('datarepo_row_id', 'c'), AddUpdateAttribute('one', 3), AddUpdateAttribute('two', 'baz'), _import_sourceid(random_snapshot_id), _import_timestamp(now)]
 
 def get_fake_parquet_translator(import_submit_time: datetime = datetime.now()) -> ParquetTranslator:
     fake_table = TDRTable('unittest', 'datarepo_row_id', [], {'test_ref_column': 'other_entity_type'})
@@ -78,13 +78,13 @@ def test_translate_parquet_file_to_entities():
     assert len(entities) == 3
     assert entities[0].name == 'a'
     assert entities[0].entityType == 'unittest'
-    assert entities[0].operations == [AddUpdateAttribute('tdr:datarepo_row_id', 'a'), AddUpdateAttribute('tdr:one', 1), AddUpdateAttribute('tdr:two', 'foo'), _import_sourceid(), _import_timestamp(now)]
+    assert entities[0].operations == [AddUpdateAttribute('datarepo_row_id', 'a'), AddUpdateAttribute('one', 1), AddUpdateAttribute('two', 'foo'), _import_sourceid(), _import_timestamp(now)]
     assert entities[1].name == 'b'
     assert entities[1].entityType == 'unittest'
-    assert entities[1].operations == [AddUpdateAttribute('tdr:datarepo_row_id', 'b'), AddUpdateAttribute('tdr:one', 2), AddUpdateAttribute('tdr:two', 'bar'), _import_sourceid(), _import_timestamp(now)]
+    assert entities[1].operations == [AddUpdateAttribute('datarepo_row_id', 'b'), AddUpdateAttribute('one', 2), AddUpdateAttribute('two', 'bar'), _import_sourceid(), _import_timestamp(now)]
     assert entities[2].name == 'c'
     assert entities[2].entityType == 'unittest'
-    assert entities[2].operations == [AddUpdateAttribute('tdr:datarepo_row_id', 'c'), AddUpdateAttribute('tdr:one', 3), AddUpdateAttribute('tdr:two', 'baz'), _import_sourceid(), _import_timestamp(now)]
+    assert entities[2].operations == [AddUpdateAttribute('datarepo_row_id', 'c'), AddUpdateAttribute('one', 3), AddUpdateAttribute('two', 'baz'), _import_sourceid(), _import_timestamp(now)]
 
 # file-like to ([Entity])
 def test_translate_parquet_file_with_missing_pk():
@@ -107,10 +107,10 @@ def test_translate_parquet_file_with_missing_pk():
     assert len(entities) == 2
     assert entities[0].name == 'first'
     assert entities[0].entityType == 'unittest'
-    assert entities[0].operations == [AddUpdateAttribute('tdr:datarepo_row_id', 'a'), AddUpdateAttribute('tdr:custompk', 'first'), AddUpdateAttribute('tdr:two', 'foo'), _import_sourceid(), _import_timestamp(now)]
+    assert entities[0].operations == [AddUpdateAttribute('datarepo_row_id', 'a'), AddUpdateAttribute('custompk', 'first'), AddUpdateAttribute('two', 'foo'), _import_sourceid(), _import_timestamp(now)]
     assert entities[1].name == 'third'
     assert entities[1].entityType == 'unittest'
-    assert entities[1].operations == [AddUpdateAttribute('tdr:datarepo_row_id', 'c'), AddUpdateAttribute('tdr:custompk', 'third'), AddUpdateAttribute('tdr:two', 'baz'), _import_sourceid(), _import_timestamp(now)]
+    assert entities[1].operations == [AddUpdateAttribute('datarepo_row_id', 'c'), AddUpdateAttribute('custompk', 'third'), AddUpdateAttribute('two', 'baz'), _import_sourceid(), _import_timestamp(now)]
 
 # file-like to ([Entity])
 def test_translate_parquet_file_with_array_attrs():
@@ -137,23 +137,23 @@ def test_translate_parquet_file_with_array_attrs():
     assert len(entities) == 3
     assert entities[0].name == 'first'
     assert entities[0].entityType == 'unittest'
-    assert entities[0].operations == [AddUpdateAttribute('tdr:datarepo_row_id', 'a'), AddUpdateAttribute('tdr:custompk', 'first'),
-        RemoveAttribute('tdr:arrayattr'), CreateAttributeValueList('tdr:arrayattr'),
-        AddListMember('tdr:arrayattr', 'Philip'), AddListMember('tdr:arrayattr', 'Glass'),
+    assert entities[0].operations == [AddUpdateAttribute('datarepo_row_id', 'a'), AddUpdateAttribute('custompk', 'first'),
+        RemoveAttribute('arrayattr'), CreateAttributeValueList('arrayattr'),
+        AddListMember('arrayattr', 'Philip'), AddListMember('arrayattr', 'Glass'),
         _import_sourceid(), _import_timestamp(now)
     ]
     assert entities[1].name == 'second'
     assert entities[1].entityType == 'unittest'
-    assert entities[1].operations == [AddUpdateAttribute('tdr:datarepo_row_id', 'b'), AddUpdateAttribute('tdr:custompk', 'second'),
-        RemoveAttribute('tdr:arrayattr'), CreateAttributeValueList('tdr:arrayattr'),
-        AddListMember('tdr:arrayattr', 'Wolfgang'), AddListMember('tdr:arrayattr', 'Amadeus'), AddListMember('tdr:arrayattr', 'Mozart'),
+    assert entities[1].operations == [AddUpdateAttribute('datarepo_row_id', 'b'), AddUpdateAttribute('custompk', 'second'),
+        RemoveAttribute('arrayattr'), CreateAttributeValueList('arrayattr'),
+        AddListMember('arrayattr', 'Wolfgang'), AddListMember('arrayattr', 'Amadeus'), AddListMember('arrayattr', 'Mozart'),
         _import_sourceid(), _import_timestamp(now)
     ]
     assert entities[2].name == 'third'
     assert entities[2].entityType == 'unittest'
-    assert entities[2].operations == [AddUpdateAttribute('tdr:datarepo_row_id', 'c'), AddUpdateAttribute('tdr:custompk', 'third'),
-        RemoveAttribute('tdr:arrayattr'), CreateAttributeValueList('tdr:arrayattr'),
-        AddListMember('tdr:arrayattr', 'Dmitri'), AddListMember('tdr:arrayattr', 'Shostakovich'),
+    assert entities[2].operations == [AddUpdateAttribute('datarepo_row_id', 'c'), AddUpdateAttribute('custompk', 'third'),
+        RemoveAttribute('arrayattr'), CreateAttributeValueList('arrayattr'),
+        AddListMember('arrayattr', 'Dmitri'), AddListMember('arrayattr', 'Shostakovich'),
         _import_sourceid(), _import_timestamp(now)
     ]
 
@@ -162,89 +162,95 @@ def test_translate_parquet_attr():
     translator = get_fake_parquet_translator()
     # translator has entityType 'unittest', so 'unittest_id' should be namespaced
     assert translator.translate_parquet_attr('unittest_id', 123) == [AddUpdateAttribute('tdr:unittest_id', 123)]
-    assert translator.translate_parquet_attr('somethingelse', 123) == [AddUpdateAttribute('tdr:somethingelse', 123)]
-    assert translator.translate_parquet_attr('datarepo_row_id', 123) == [AddUpdateAttribute('tdr:datarepo_row_id', 123)]
+    assert translator.translate_parquet_attr('somethingelse', 123) == [AddUpdateAttribute('somethingelse', 123)]
+    assert translator.translate_parquet_attr('datarepo_row_id', 123) == [AddUpdateAttribute('datarepo_row_id', 123)]
 
-    assert translator.translate_parquet_attr('foo', True) == [AddUpdateAttribute('tdr:foo', True)]
-    assert translator.translate_parquet_attr('foo', 'astring') == [AddUpdateAttribute('tdr:foo', 'astring')]
-    assert translator.translate_parquet_attr('foo', 123) == [AddUpdateAttribute('tdr:foo', 123)]
-    assert translator.translate_parquet_attr('foo', 456.78) == [AddUpdateAttribute('tdr:foo', 456.78)]
+    # name should always be namespaced
+    assert translator.translate_parquet_attr('name', 123) == [AddUpdateAttribute('tdr:name', 123)]
+
+    # import should always be namespaced
+    assert translator.translate_parquet_attr('fake_timestamp', 123, 'import') == [AddUpdateAttribute('import:fake_timestamp', 123)]
+
+    assert translator.translate_parquet_attr('foo', True) == [AddUpdateAttribute('foo', True)]
+    assert translator.translate_parquet_attr('foo', 'astring') == [AddUpdateAttribute('foo', 'astring')]
+    assert translator.translate_parquet_attr('foo', 123) == [AddUpdateAttribute('foo', 123)]
+    assert translator.translate_parquet_attr('foo', 456.78) == [AddUpdateAttribute('foo', 456.78)]
 
     # entity reference attribute tests
     assert translator.translate_parquet_attr('test_ref_column', 'some_sample') == \
-        [AddUpdateAttribute('tdr:test_ref_column', EntityReference('some_sample', 'other_entity_type'))]
+        [AddUpdateAttribute('test_ref_column', EntityReference('some_sample', 'other_entity_type'))]
 
     curtime = datetime.now()
-    assert translator.translate_parquet_attr('foo', curtime) == [AddUpdateAttribute('tdr:foo', str(curtime))]
+    assert translator.translate_parquet_attr('foo', curtime) == [AddUpdateAttribute('foo', str(curtime))]
 
     arr = ['a', 'b', 'c']
-    assert translator.translate_parquet_attr('foo', arr) == [AddUpdateAttribute('tdr:foo', str(arr))]
+    assert translator.translate_parquet_attr('foo', arr) == [AddUpdateAttribute('foo', str(arr))]
 
 def test_translate_parquet_attr_arrays():
     translator = get_fake_parquet_translator()
 
     assert translator.translate_parquet_attr('myarray', np.array([1, 2, 3])) == [
-        RemoveAttribute('tdr:myarray'), CreateAttributeValueList('tdr:myarray'),
-        AddListMember('tdr:myarray', 1), AddListMember('tdr:myarray', 2), AddListMember('tdr:myarray', 3)]
+        RemoveAttribute('myarray'), CreateAttributeValueList('myarray'),
+        AddListMember('myarray', 1), AddListMember('myarray', 2), AddListMember('myarray', 3)]
 
     assert translator.translate_parquet_attr('myarray', np.array(['foo', 'bar'])) == [
-        RemoveAttribute('tdr:myarray'), CreateAttributeValueList('tdr:myarray'),
-        AddListMember('tdr:myarray', 'foo'), AddListMember('tdr:myarray', 'bar')]
+        RemoveAttribute('myarray'), CreateAttributeValueList('myarray'),
+        AddListMember('myarray', 'foo'), AddListMember('myarray', 'bar')]
 
     time1 = datetime.now()
     time2 = datetime.now()
     assert translator.translate_parquet_attr('myarray', np.array([time1, time2])) == [
-        RemoveAttribute('tdr:myarray'), CreateAttributeValueList('tdr:myarray'),
-        AddListMember('tdr:myarray', str(time1)), AddListMember('tdr:myarray', str(time2))]
+        RemoveAttribute('myarray'), CreateAttributeValueList('myarray'),
+        AddListMember('myarray', str(time1)), AddListMember('myarray', str(time2))]
 
 def test_translate_parq_reference_arrays():
     translator = get_fake_parquet_translator()
 
     assert translator.translate_parquet_attr('test_ref_column', np.array(['sample1', 'sample2'])) == [
-        RemoveAttribute('tdr:test_ref_column'), CreateAttributeEntityReferenceList('tdr:test_ref_column'),
-        AddListMember('tdr:test_ref_column', EntityReference('sample1', 'other_entity_type')),
-        AddListMember('tdr:test_ref_column', EntityReference('sample2', 'other_entity_type'))
+        RemoveAttribute('test_ref_column'), CreateAttributeEntityReferenceList('test_ref_column'),
+        AddListMember('test_ref_column', EntityReference('sample1', 'other_entity_type')),
+        AddListMember('test_ref_column', EntityReference('sample2', 'other_entity_type'))
     ]
 
 def test_translate_parquet_attr_null():
     translator = get_fake_parquet_translator()
 
-    assert translator.translate_parquet_attr('containsnull', None) == [AddUpdateAttribute('tdr:containsnull', None)]
+    assert translator.translate_parquet_attr('containsnull', None) == [AddUpdateAttribute('containsnull', None)]
 
 def test_translate_parquet_attr_NaN():
     translator = get_fake_parquet_translator()
 
-    assert translator.translate_parquet_attr('containsNaN', np.nan) == [AddUpdateAttribute('tdr:containsNaN', None)]
+    assert translator.translate_parquet_attr('containsNaN', np.nan) == [AddUpdateAttribute('containsNaN', None)]
 
 def test_translate_parquet_attr_arrays_containing_null():
     translator = get_fake_parquet_translator()
 
     assert translator.translate_parquet_attr('myarray', np.array([1, 2, None, 4])) == [
-        RemoveAttribute('tdr:myarray'), CreateAttributeValueList('tdr:myarray'),
-        AddListMember('tdr:myarray', 1), AddListMember('tdr:myarray', 2),
-        AddListMember('tdr:myarray', None), AddListMember('tdr:myarray', 4)]
+        RemoveAttribute('myarray'), CreateAttributeValueList('myarray'),
+        AddListMember('myarray', 1), AddListMember('myarray', 2),
+        AddListMember('myarray', None), AddListMember('myarray', 4)]
 
     assert translator.translate_parquet_attr('myarray', np.array(['foo', None, 'bar'])) == [
-        RemoveAttribute('tdr:myarray'), CreateAttributeValueList('tdr:myarray'),
-        AddListMember('tdr:myarray', 'foo'), AddListMember('tdr:myarray', None), AddListMember('tdr:myarray', 'bar')]
+        RemoveAttribute('myarray'), CreateAttributeValueList('myarray'),
+        AddListMember('myarray', 'foo'), AddListMember('myarray', None), AddListMember('myarray', 'bar')]
 
     assert translator.translate_parquet_attr('myarray', np.array([False, None, True])) == [
-        RemoveAttribute('tdr:myarray'), CreateAttributeValueList('tdr:myarray'),
-        AddListMember('tdr:myarray', False), AddListMember('tdr:myarray', None), AddListMember('tdr:myarray', True)]
+        RemoveAttribute('myarray'), CreateAttributeValueList('myarray'),
+        AddListMember('myarray', False), AddListMember('myarray', None), AddListMember('myarray', True)]
 
     time1 = datetime.now()
     time2 = datetime.now()
     assert translator.translate_parquet_attr('myarray', np.array([time1, None, time2])) == [
-        RemoveAttribute('tdr:myarray'), CreateAttributeValueList('tdr:myarray'),
-        AddListMember('tdr:myarray', str(time1)), AddListMember('tdr:myarray', None),AddListMember('tdr:myarray', str(time2))]
+        RemoveAttribute('myarray'), CreateAttributeValueList('myarray'),
+        AddListMember('myarray', str(time1)), AddListMember('myarray', None),AddListMember('myarray', str(time2))]
 
 def test_translate_parquet_attr_arrays_containing_NaN():
     translator = get_fake_parquet_translator()
 
     assert translator.translate_parquet_attr('myarray', np.array([1, 2, np.nan, 4])) == [
-        RemoveAttribute('tdr:myarray'), CreateAttributeValueList('tdr:myarray'),
-        AddListMember('tdr:myarray', 1), AddListMember('tdr:myarray', 2),
-        AddListMember('tdr:myarray', None), AddListMember('tdr:myarray', 4)]
+        RemoveAttribute('myarray'), CreateAttributeValueList('myarray'),
+        AddListMember('myarray', 1), AddListMember('myarray', 2),
+        AddListMember('myarray', None), AddListMember('myarray', 4)]
 
 def test_actual_parquet_file_with_NaN():
     translator = get_fake_parquet_translator()
@@ -264,10 +270,29 @@ def test_actual_parquet_file_with_NaN():
         e: Entity = entities[0]
         assert len(e.operations) == 65
         # spot-check a few of the attributes
-        assert_attr_value(e.operations, 'tdr:VerifyBam_LC_Affy_Chip', None) # Float, contains null in BQ
-        assert_attr_value(e.operations, 'tdr:VerifyBam_E_Affy_Chip', None) # Float, contains null in BQ
-        assert_attr_value(e.operations, 'tdr:Grandparents', '') # String, contains empty string in BQ
-        assert_attr_value(e.operations, 'tdr:VerifyBam_LC_Omni_Chip', 0.00026) # Float, contains 2.6E-4 in BQ
-        assert_attr_value(e.operations, 'tdr:In_Final_Phase_Variant_Calling', True) # Boolean, contains true in BQ
-        assert_attr_value(e.operations, 'tdr:In_Low_Coverage_Pilot', None)  # Boolean, contains null in BQ
-        assert_attr_value(e.operations, 'tdr:Population_Description', 'British in England and Scotland') # String, contains 'British in England and Scotland' in BQ
+        assert_attr_value(e.operations, 'VerifyBam_LC_Affy_Chip', None) # Float, contains null in BQ
+        assert_attr_value(e.operations, 'VerifyBam_E_Affy_Chip', None) # Float, contains null in BQ
+        assert_attr_value(e.operations, 'Grandparents', '') # String, contains empty string in BQ
+        assert_attr_value(e.operations, 'VerifyBam_LC_Omni_Chip', 0.00026) # Float, contains 2.6E-4 in BQ
+        assert_attr_value(e.operations, 'In_Final_Phase_Variant_Calling', True) # Boolean, contains true in BQ
+        assert_attr_value(e.operations, 'In_Low_Coverage_Pilot', None)  # Boolean, contains null in BQ
+        assert_attr_value(e.operations, 'Population_Description', 'British in England and Scotland') # String, contains 'British in England and Scotland' in BQ
+
+def test_if_namespace_prefix_will_be_added():
+    tdr_namespace = 'tdr'
+
+    # prefix is always required for the import prefix (or other non-tdr prefixes)
+    assert ParquetTranslator.prefix_required('fake_timestamp', 'import', 'any', 'anykey')
+
+    # prefix is always required for 'name'
+    assert ParquetTranslator.prefix_required('name', tdr_namespace, 'any', 'anykey')
+    
+    # prefix is required if it's not the primary key but is tableName_id
+    assert ParquetTranslator.prefix_required('sample_id', tdr_namespace, 'sample', 'notsample_id')
+
+    # otherwise no prefix!
+    assert not ParquetTranslator.prefix_required('sample_id', tdr_namespace, 'sample', 'sample_id')
+    assert not ParquetTranslator.prefix_required('aliquot_id', tdr_namespace, 'sample', 'sample_id')
+    assert not ParquetTranslator.prefix_required('bam', tdr_namespace, 'sample', 'sample_id')
+    assert not ParquetTranslator.prefix_required('aliquot_id', tdr_namespace, 'sample', 'aliquot_id')
+    assert not ParquetTranslator.prefix_required('sample_id_id', tdr_namespace, 'sample', 'notsample_id')

--- a/app/tests/test_tdr_manifest_to_rawls.py
+++ b/app/tests/test_tdr_manifest_to_rawls.py
@@ -286,7 +286,7 @@ def test_if_namespace_prefix_will_be_added():
 
     # prefix is always required for 'name'
     assert ParquetTranslator.prefix_required('name', tdr_namespace, 'any', 'anykey')
-    
+
     # prefix is required if it's not the primary key but is tableName_id
     assert ParquetTranslator.prefix_required('sample_id', tdr_namespace, 'sample', 'notsample_id')
 

--- a/app/translators/tdr_manifest_to_rawls.py
+++ b/app/translators/tdr_manifest_to_rawls.py
@@ -165,11 +165,11 @@ class ParquetTranslator:
                 # natively serializable into JSON, such as Timestamps. Inspect the types we know about,
                 # and str() the rest of them.
                 return str(value)
-    
-    # only add TDR namespace if needed. See this doc: 
+
+    # only add TDR namespace if needed. See this doc:
     # https://docs.google.com/document/d/1_dEbPtgF7eeYUNRFK6CDUqeGWtiE9ISeTlfjSEtl-FA
     @staticmethod
-    def prefix_required(name: str, namespace: str, table_name: str, primary_key: str) -> bool: 
+    def prefix_required(name: str, namespace: str, table_name: str, primary_key: str) -> bool:
         return namespace != 'tdr' \
             or name == 'name' \
             or (name.endswith('_id') and name[:-3] == table_name and name != primary_key)


### PR DESCRIPTION
increases the column length in the sqlalchemy model definitions from 100 -> 254 chars.

The Rawls db uses varchar(254) for these columns, so import service should too, else it risks truncating data.

Note that the sqlalchemy length is currently irrelevant for us - it is only used for `CREATE TABLE` statements, which we don't use in prod: https://docs.sqlalchemy.org/en/14/core/type_basics.html#sqlalchemy.types.String. The real change for AJ-306 will happen outside of this PR as I change the dbs themselves. I have already changed the column lengths for dev and will do so soon for alpha through prod.