### PR TITLE
increase length of workspace namespace,name cols [AJ-306]

### DIFF
--- a/app/db/model.py
+++ b/app/db/model.py
@@ -107,8 +107,8 @@ class Import(ImportServiceTable, EqMixin, Base):
     __tablename__ = 'imports'
 
     id = Column(String(36), primary_key=True)
-    workspace_name = Column(String(100), nullable=False)
-    workspace_namespace = Column(String(100), nullable=False)
+    workspace_name = Column(String(254), nullable=False)
+    workspace_namespace = Column(String(254), nullable=False)
     workspace_uuid = Column(String(36), nullable=False)
     workspace_google_project = Column(String(30), nullable=False)
     submitter = Column(String(100), nullable=False)


### PR DESCRIPTION
increases the column length in the sqlalchemy model definitions from 100 -> 254 chars.

The Rawls db uses varchar(254) for these columns, so import service should too, else it risks truncating data.

Note that the sqlalchemy length is currently irrelevant for us - it is only used for `CREATE TABLE` statements, which we don't use in prod: https://docs.sqlalchemy.org/en/14/core/type_basics.html#sqlalchemy.types.String. The real change for AJ-306 will happen outside of this PR as I change the dbs themselves. I have already changed the column lengths for dev through staging and will do so soon for prod.