### PR TITLE
Aj 404 update cloud logging

### DIFF
--- a/app/external/rawls.py
+++ b/app/external/rawls.py
@@ -17,12 +17,13 @@ def get_workspace_uuid_and_project(workspace_namespace: str, workspace_name: str
         f"{os.environ.get('RAWLS_URL')}/api/workspaces/{workspace_namespace}/{workspace_name}?fields=workspace.workspaceId,workspace.googleProject",
         headers={"Authorization": bearer_token})
 
+    jso = resp.json()
     if resp.ok:
-        jso = resp.json()
         return RawlsWorkspaceResponse(workspace_id=jso["workspace"]["workspaceId"], google_project=jso["workspace"]["googleProject"])
     else:
         # just pass the error upwards
-        logging.info(f"Got {resp.status_code} from Rawls for {workspace_namespace}/{workspace_name}: {resp.text}")
+        logging.info(f"Got {resp.status_code} from Rawls for {workspace_namespace}/{workspace_name}: {jso['message']}",
+                     extra={"json_fields": jso})
         raise ISvcException(resp.text, resp.status_code)
 
 def check_workspace_iam_action(workspace_namespace: str, workspace_name: str, action: str, bearer_token: str) -> bool:
@@ -36,7 +37,9 @@ def check_workspace_iam_action(workspace_namespace: str, workspace_name: str, ac
         return False
     else:
         # just pass the error upwards
-        logging.info(f"Got {resp.status_code} from Rawls for {workspace_namespace}/{workspace_name}: {resp.text}")
+        jso = resp.json()
+        logging.info(f"Got {resp.status_code} from Rawls for {workspace_namespace}/{workspace_name}: {jso['message']}",
+                     extra={"json_fields": jso})
         raise ISvcException(resp.text, resp.status_code)
 
 

--- a/app/external/rawls.py
+++ b/app/external/rawls.py
@@ -22,7 +22,9 @@ def get_workspace_uuid_and_project(workspace_namespace: str, workspace_name: str
         return RawlsWorkspaceResponse(workspace_id=jso["workspace"]["workspaceId"], google_project=jso["workspace"]["googleProject"])
     else:
         # just pass the error upwards
-        logging.info(f"Got {resp.status_code} from Rawls for {workspace_namespace}/{workspace_name}: {resp.text}")
+        workspace_dict = { 'workspace': { 'namespace': workspace_namespace, 'name': workspace_name} }
+        logging.info(f"Got {resp.status_code} from Rawls for {workspace_namespace}/{workspace_name}: {resp.text}",
+                     extra={"json_fields": workspace_dict})
         raise ISvcException(resp.text, resp.status_code)
 
 def check_workspace_iam_action(workspace_namespace: str, workspace_name: str, action: str, bearer_token: str) -> bool:

--- a/app/external/rawls.py
+++ b/app/external/rawls.py
@@ -17,13 +17,12 @@ def get_workspace_uuid_and_project(workspace_namespace: str, workspace_name: str
         f"{os.environ.get('RAWLS_URL')}/api/workspaces/{workspace_namespace}/{workspace_name}?fields=workspace.workspaceId,workspace.googleProject",
         headers={"Authorization": bearer_token})
 
-    jso = resp.json()
     if resp.ok:
+        jso = resp.json()
         return RawlsWorkspaceResponse(workspace_id=jso["workspace"]["workspaceId"], google_project=jso["workspace"]["googleProject"])
     else:
         # just pass the error upwards
-        logging.info(f"Got {resp.status_code} from Rawls for {workspace_namespace}/{workspace_name}: {jso['message']}",
-                     extra={"json_fields": jso})
+        logging.info(f"Got {resp.status_code} from Rawls for {workspace_namespace}/{workspace_name}: {resp.text}")
         raise ISvcException(resp.text, resp.status_code)
 
 def check_workspace_iam_action(workspace_namespace: str, workspace_name: str, action: str, bearer_token: str) -> bool:
@@ -37,9 +36,7 @@ def check_workspace_iam_action(workspace_namespace: str, workspace_name: str, ac
         return False
     else:
         # just pass the error upwards
-        jso = resp.json()
-        logging.info(f"Got {resp.status_code} from Rawls for {workspace_namespace}/{workspace_name}: {jso['message']}",
-                     extra={"json_fields": jso})
+        logging.info(f"Got {resp.status_code} from Rawls for {workspace_namespace}/{workspace_name}: {resp.text}")
         raise ISvcException(resp.text, resp.status_code)
 
 

--- a/main.py
+++ b/main.py
@@ -1,29 +1,9 @@
-import logging, os, sys
+import os
 from app import create_app
 import google.cloud.logging
 
 client = google.cloud.logging.Client()
 client.setup_logging()
-
-
-
-# # Google's suggested integration with Stackdriver logging produces duplicate logs in Stackdriver.
-# # This does it right. See https://stackoverflow.com/a/58655297/2941784
-# if "GAE_APPLICATION" in os.environ:
-#     from google.cloud.logging.handlers import AppEngineHandler
-#     import google.cloud.logging as glogging
-#     client = glogging.Client()
-#     formatter = logging.Formatter("%(module)s.%(funcName)s: %(message)s")
-#     handler = AppEngineHandler(client, stream=sys.stderr)
-#     handler.setFormatter(formatter)
-#     handler.setLevel(logging.INFO)
-#     root = logging.getLogger()
-#     root.addHandler(handler)
-#     root.setLevel(logging.INFO)
-# else:
-#     # For local runs, use normal Python logging (so we don't send all our test logs to Stackdriver!)
-#     logging.basicConfig(format="%(module)s.%(funcName)s: %(message)s", level=logging.INFO)
-
 
 app = create_app()
 

--- a/main.py
+++ b/main.py
@@ -1,9 +1,13 @@
-import os
+import logging, os
 from app import create_app
 import google.cloud.logging
 
-client = google.cloud.logging.Client()
-client.setup_logging()
+if "GAE_APPLICATION" in os.environ:
+    client = google.cloud.logging.Client()
+    client.setup_logging()
+else:
+    # For local runs, use normal Python logging (so we don't send all our test logs to Stackdriver!)
+    logging.basicConfig(format="%(module)s.%(funcName)s: %(message)s", level=logging.INFO)
 
 app = create_app()
 

--- a/main.py
+++ b/main.py
@@ -1,23 +1,28 @@
 import logging, os, sys
 from app import create_app
+import google.cloud.logging
+
+client = google.cloud.logging.Client()
+client.setup_logging()
 
 
-# Google's suggested integration with Stackdriver logging produces duplicate logs in Stackdriver.
-# This does it right. See https://stackoverflow.com/a/58655297/2941784
-if "GAE_APPLICATION" in os.environ:
-    from google.cloud.logging.handlers import AppEngineHandler
-    import google.cloud.logging as glogging
-    client = glogging.Client()
-    formatter = logging.Formatter("%(module)s.%(funcName)s: %(message)s")
-    handler = AppEngineHandler(client, stream=sys.stderr)
-    handler.setFormatter(formatter)
-    handler.setLevel(logging.INFO)
-    root = logging.getLogger()
-    root.addHandler(handler)
-    root.setLevel(logging.INFO)
-else:
-    # For local runs, use normal Python logging (so we don't send all our test logs to Stackdriver!)
-    logging.basicConfig(format="%(module)s.%(funcName)s: %(message)s", level=logging.INFO)
+
+# # Google's suggested integration with Stackdriver logging produces duplicate logs in Stackdriver.
+# # This does it right. See https://stackoverflow.com/a/58655297/2941784
+# if "GAE_APPLICATION" in os.environ:
+#     from google.cloud.logging.handlers import AppEngineHandler
+#     import google.cloud.logging as glogging
+#     client = glogging.Client()
+#     formatter = logging.Formatter("%(module)s.%(funcName)s: %(message)s")
+#     handler = AppEngineHandler(client, stream=sys.stderr)
+#     handler.setFormatter(formatter)
+#     handler.setLevel(logging.INFO)
+#     root = logging.getLogger()
+#     root.addHandler(handler)
+#     root.setLevel(logging.INFO)
+# else:
+#     # For local runs, use normal Python logging (so we don't send all our test logs to Stackdriver!)
+#     logging.basicConfig(format="%(module)s.%(funcName)s: %(message)s", level=logging.INFO)
 
 
 app = create_app()

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ sqlalchemy==1.4.28
 sqlalchemy-stubs==0.4
 sqlalchemy-repr==0.0.2
 pymysql==1.0.2
-google-cloud-logging==2.7.0
+google-cloud-logging==3.0.0
 google-auth==2.3.3
 google-api-python-client==2.33.0
 google-cloud-pubsub==2.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ sqlalchemy==1.4.28
 sqlalchemy-stubs==0.4
 sqlalchemy-repr==0.0.2
 pymysql==1.0.2
-google-cloud-logging==3.0.0
+google-cloud-logging==2.7.0
 google-auth==2.3.3
 google-api-python-client==2.33.0
 google-cloud-pubsub==2.9.0


### PR DESCRIPTION
AJ-404
- Updates google cloud logging from version 2.7 to 3.0.
- Removes workaround - no double logging seen. 
- Added custom json fields to logging in rawls to demonstrate possibility.  The old message was the entire http response.  Now it is just the message, with the rest of the response under 'jsonPayload'.

To generate json fields logging, try importing a snapshot to a workspace that doesn't exist.

I noticed two further changes from the update:

1. Relevant logs will be under the 'python' log.  Previously, they were found under 'app'.
<img width="1215" alt="logExplorer" src="https://user-images.githubusercontent.com/5884792/167938767-21cd8db3-3f45-4023-a394-a0570ae5efbc.png">

2. Source method of the log used to be printed directly in the top level message

<img width="1111" alt="2 7nojson_fields" src="https://user-images.githubusercontent.com/5884792/167935913-47155d17-5078-403e-87ca-e6dc3c17eb43.png">

Now you must look inside for sourceLocation:

<img width="1196" alt="3 0withjson_fields_sourceLocation" src="https://user-images.githubusercontent.com/5884792/167936094-2e306d40-f9b8-4f85-b007-481968a593a9.png">

This appears to be an automatic change, but you can display the source file and method by editing the summary display:

<img width="1184" alt="editsummary" src="https://user-images.githubusercontent.com/5884792/167936263-3c546dc6-55e7-4f44-baaf-80d041281370.png">