### PR TITLE
dont create array member if source is None [needs ticket]

### DIFF
--- a/app/tests/test_pfb_to_rawls.py
+++ b/app/tests/test_pfb_to_rawls.py
@@ -80,3 +80,24 @@ def test_translate_pfb_file_with_array_to_entities(fake_import, fake_pfb_with_ar
         AddListMember(array_prop, '22222222-2222-2222-2222-222222222222')]
     assert actual == expected
 
+def test_none_values_in_array():
+    translator = PFBToRawls()
+    rec = {
+        'name': 'foo',
+        'id': 'bar',
+        'object': {
+            'arr': [1, None, 2, None, 3, ],
+        },
+        'relations': {}
+    }
+    entity = translator.translate_record(rec, {}, 'pfb')
+
+    expectedops = [
+        RemoveAttribute('pfb:arr'),
+        CreateAttributeValueList('pfb:arr'),
+        AddListMember('pfb:arr', 1),
+        AddListMember('pfb:arr', 2),
+        AddListMember('pfb:arr', 3)
+    ]
+
+    assert entity.operations == expectedops

--- a/app/translators/pfb_to_rawls.py
+++ b/app/translators/pfb_to_rawls.py
@@ -48,7 +48,7 @@ class PFBToRawls(Translator):
                 key = file_type + ':' + key
 
             if isinstance(value, list):
-                ops = [AddListMember(key, v) for v in value]
+                ops = [AddListMember(key, v) for v in value if value is not None]
                 return [RemoveAttribute(key), CreateAttributeValueList(key), *ops]
             else:
                 return [AddUpdateAttribute(key, value)]

--- a/app/translators/pfb_to_rawls.py
+++ b/app/translators/pfb_to_rawls.py
@@ -48,7 +48,7 @@ class PFBToRawls(Translator):
                 key = file_type + ':' + key
 
             if isinstance(value, list):
-                ops = [AddListMember(key, v) for v in value if value is not None]
+                ops = [AddListMember(key, v) for v in value if v is not None]
                 return [RemoveAttribute(key), CreateAttributeValueList(key), *ops]
             else:
                 return [AddUpdateAttribute(key, value)]


### PR DESCRIPTION
When creating list members for PFB imports, don't create a member if the source value is `None`