### PR TITLE
[AJ-608] fix attribute list name string

### DIFF
--- a/app/external/rawls_entity_model.py
+++ b/app/external/rawls_entity_model.py
@@ -42,7 +42,7 @@ class CreateAttributeValueList(AttributeOperation):
 
 @dataclass
 class CreateAttributeEntityReferenceList(AttributeOperation):
-    attributeName: str
+    attributeListName: str
     op: str = 'CreateAttributeEntityReferenceList'
 
 @dataclass


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-608

Imports for TDR snapshots with Attribute Lists are failing for references, the string appears to be incorrect