### PR TITLE
[AJ-1129] Validate GCS URLs in tdrexport requests

### DIFF
--- a/app/new_import.py
+++ b/app/new_import.py
@@ -82,9 +82,12 @@ def is_protected_workspace(authorization_domain: Optional[Set[str]], bucket_name
     return bucket_name and bucket_name.startswith("fc-secure")
 
 @validate_arguments
-def validate_and_parse_url(url: AnyUrl) -> ParseResult:
+def _validate_url(url: AnyUrl) -> str:
+    return str(url)
+
+def validate_and_parse_url(url: str) -> ParseResult:
     """Validates the input URL using pydantic and parses it with urlparse."""
-    return urlparse(str(url))
+    return urlparse(_validate_url(url)) # type: ignore
 
 def validate_import_url(import_url: Optional[str], import_filetype: Optional[str], user_info: UserInfo) -> str:
     """Inspects the URI from which the user wants to import data. Because our service will make an

--- a/app/new_import.py
+++ b/app/new_import.py
@@ -7,8 +7,9 @@ from app.external import sam, pubsub
 from app.auth import user_auth
 from app.util import exceptions
 
+from pydantic import AnyUrl, validate_arguments
 from typing import Optional, Set
-from urllib.parse import urlparse
+from urllib.parse import ParseResult, urlparse
 import os
 
 from app.auth.userinfo import UserInfo
@@ -80,6 +81,11 @@ def is_protected_workspace(authorization_domain: Optional[Set[str]], bucket_name
         return True
     return bucket_name and bucket_name.startswith("fc-secure")
 
+@validate_arguments
+def validate_and_parse_url(url: AnyUrl) -> ParseResult:
+    """Validates the input URL using pydantic and parses it with urlparse."""
+    return urlparse(str(url))
+
 def validate_import_url(import_url: Optional[str], import_filetype: Optional[str], user_info: UserInfo) -> str:
     """Inspects the URI from which the user wants to import data. Because our service will make an
     outbound request to the user-supplied URI, we want to make sure that our service only visits
@@ -98,7 +104,7 @@ def validate_import_url(import_url: Optional[str], import_filetype: Optional[str
         raise exceptions.InvalidFiletypeException(import_filetype, user_info, "Missing filetype")
 
     try:
-        parsedurl = urlparse(import_url)
+        parsedurl = validate_and_parse_url(import_url)
     except Exception as e:
         # catch any/all exceptions here so we can ensure audit logging
         raise exceptions.InvalidPathException(import_url, user_info, f"{e}")

--- a/app/new_import.py
+++ b/app/new_import.py
@@ -87,6 +87,8 @@ def _validate_url(url: AnyUrl) -> str:
 
 def validate_and_parse_url(url: str) -> ParseResult:
     """Validates the input URL using pydantic and parses it with urlparse."""
+    # Mypy expects _validate_url to take an AnyUrl argument, but it actually can accept a string, which pydantic
+    # will coerce into an AnyUrl. Breaking this up into two functions keeps the type: ignore confined here.
     return urlparse(_validate_url(url)) # type: ignore
 
 def validate_import_url(import_url: Optional[str], import_filetype: Optional[str], user_info: UserInfo) -> str:

--- a/app/tests/test_path_validation.py
+++ b/app/tests/test_path_validation.py
@@ -46,8 +46,13 @@ def test_unparsable_path(client: flask.testing.FlaskClient, caplog):
     assert_response_code_and_logs(resp, caplog, payload["path"])
 
 @pytest.mark.usefixtures("sam_valid_user", "user_has_ws_access", "pubsub_publish", "pubsub_fake_env")
-def test_invalid_tdrexport_gcs_url(client):
-    payload = {"path": "gs://bucket https://example.com/foo", "filetype": "tdrexport"}
+@pytest.mark.parametrize("path,filetype", [
+    ("gs://bucket https://example.com/foo", "tdrexport"),
+    ("https://*/foo", "tdrexport"),
+    ("https://example.com https://example.com", "pfb"),
+])
+def test_invalid_url(client, path, filetype):
+    payload = {"path": path, "filetype": filetype}
     resp = client.post('/namespace/name/imports', json=payload, headers=good_headers)
     assert resp.status_code == 400
 

--- a/app/tests/test_path_validation.py
+++ b/app/tests/test_path_validation.py
@@ -20,7 +20,6 @@ def assert_response_code_and_logs(resp, caplog, import_url):
 user_info = UserInfo("subject-id", "awesomepossum@broadinstitute.org", True)
 @pytest.mark.parametrize("netloc", new_import.VALID_NETLOCS + ["something.anvil.gi.ucsc.edu/manifest/files",
                                                               "something-else.anvil.gi.ucsc.edu/manifest/files",
-                                                              "*.anvil.gi.ucsc.edu/manifest/files",
                                                               "something.anvil.gi.ucsc.edu"])
 @pytest.mark.parametrize("filetype", translate.FILETYPE_TRANSLATORS.keys())
 @pytest.mark.usefixtures("sam_valid_user", "user_has_ws_access", "pubsub_publish", "pubsub_fake_env")
@@ -45,6 +44,12 @@ def test_unparsable_path(client: flask.testing.FlaskClient, caplog):
     payload = {"path": f"https://[:-999/~~~~~~~~~~~", "filetype": "pfb"}
     resp = client.post('/namespace/name/imports', json=payload, headers=good_headers)
     assert_response_code_and_logs(resp, caplog, payload["path"])
+
+@pytest.mark.usefixtures("sam_valid_user", "user_has_ws_access", "pubsub_publish", "pubsub_fake_env")
+def test_invalid_tdrexport_gcs_url(client):
+    payload = {"path": "gs://bucket https://example.com/foo", "filetype": "tdrexport"}
+    resp = client.post('/namespace/name/imports', json=payload, headers=good_headers)
+    assert resp.status_code == 400
 
 @pytest.mark.parametrize("netloc", new_import.VALID_NETLOCS)
 @pytest.mark.usefixtures("sam_valid_user", "user_has_ws_access", "pubsub_publish", "pubsub_fake_env")


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1129

Currently, when a `tdrexport` import is created with a GCS URL, the only validation done on the URL is that it starts with `gs://`.

https://github.com/broadinstitute/import-service/blob/63c1c98a5851c064a4150a820e476f164189502a/app/new_import.py#L117-L118

Note that Python's `urlparse` does _not_ perform validation.
https://docs.python.org/3.9/library/urllib.parse.html#url-parsing-security

This adds validation of the URL using Pydantic's [AnyUrl](https://docs.pydantic.dev/1.10/usage/types/#urls) type.
