### PR TITLE
[AJ-1192] Configure allowed netlocs for imports per-environment

### DIFF
--- a/app.yaml.ctmpl
+++ b/app.yaml.ctmpl
@@ -66,6 +66,8 @@ env_variables:
  RAWLS_PUBSUB_PROJECT: "broad-dsde-{{$env}}"
  RAWLS_PUBSUB_TOPIC: "rawls-async-import-topic-{{$env}}"
 
+ IMPORT_ALLOWED_NETLOCS: {{if eq $env "prod"}}"service.prod.anvil.gi.ucsc.edu,*dev.singlecell.gi.ucsc.edu,*gen3.biodatacatalyst.nhlbi.nih.gov,gen3-biodatacatalyst-nhlbi-nih-gov-pfb-export.s3.amazonaws.com,gen3-theanvil-io-pfb-export.s3.amazonaws.com,*service.azul.data.humancellatlas.org"
+                         {{else}}"service.anvil.gi.ucsc.edu,*dev.singlecell.gi.ucsc.edu,*gen3.biodatacatalyst.nhlbi.nih.gov,gen3-biodatacatalyst-nhlbi-nih-gov-pfb-export.s3.amazonaws.com,gen3-theanvil-io-pfb-export.s3.amazonaws.com,*service.azul.data.humancellatlas.org"{{end}}
 
 {{end}}{{end}}{{end}}{{end}}{{end}}{{end}}{{end}}{{end}}{{end}}
 

--- a/app.yaml.ctmpl
+++ b/app.yaml.ctmpl
@@ -66,8 +66,7 @@ env_variables:
  RAWLS_PUBSUB_PROJECT: "broad-dsde-{{$env}}"
  RAWLS_PUBSUB_TOPIC: "rawls-async-import-topic-{{$env}}"
 
- IMPORT_ALLOWED_NETLOCS: {{if eq $env "prod"}}"service.prod.anvil.gi.ucsc.edu,*dev.singlecell.gi.ucsc.edu,*gen3.biodatacatalyst.nhlbi.nih.gov,gen3-biodatacatalyst-nhlbi-nih-gov-pfb-export.s3.amazonaws.com,gen3-theanvil-io-pfb-export.s3.amazonaws.com,*service.azul.data.humancellatlas.org"
-                         {{else}}"service.anvil.gi.ucsc.edu,*dev.singlecell.gi.ucsc.edu,*gen3.biodatacatalyst.nhlbi.nih.gov,gen3-biodatacatalyst-nhlbi-nih-gov-pfb-export.s3.amazonaws.com,gen3-theanvil-io-pfb-export.s3.amazonaws.com,*service.azul.data.humancellatlas.org"{{end}}
+ IMPORT_ALLOWED_NETLOCS: "{{if eq $env "prod"}}service.prod.anvil.gi.ucsc.edu{{else}}service.anvil.gi.ucsc.edu{{end}},*dev.singlecell.gi.ucsc.edu,*gen3.biodatacatalyst.nhlbi.nih.gov,*service.azul.data.humancellatlas.org"
 
 {{end}}{{end}}{{end}}{{end}}{{end}}{{end}}{{end}}{{end}}{{end}}
 

--- a/app/new_import.py
+++ b/app/new_import.py
@@ -14,7 +14,7 @@ import os
 
 from app.auth.userinfo import UserInfo
 
-PROTECTED_NETLOCS = ["anvil.gi.ucsc.edu", "anvilproject.org", "gen3.biodatacatalyst.nhlbi.nih.gov", "gen3-biodatacatalyst-nhlbi-nih-gov-pfb-export.s3.amazonaws.com", "gen3-theanvil-io-pfb-export.s3.amazonaws.com"]
+PROTECTED_NETLOCS = ["service.prod.anvil.gi.ucsc.edu", "service.anvil.gi.ucsc.edu", "gen3.biodatacatalyst.nhlbi.nih.gov", "gen3-biodatacatalyst-nhlbi-nih-gov-pfb-export.s3.amazonaws.com", "gen3-theanvil-io-pfb-export.s3.amazonaws.com"]
 
 # Allow downloads from any GCS bucket, Azure storage container, or S3 bucket
 VALID_NETLOCS = ["storage.googleapis.com", "*.core.windows.net", "*.s3.amazonaws.com"]

--- a/app/tests/test_new_import.py
+++ b/app/tests/test_new_import.py
@@ -185,9 +185,8 @@ def test_validate_import_url(import_url, netloc, file_type_translator):
         assert validate_import_url(import_url=import_url, import_filetype=file_type_translator, user_info=user_info) == netloc
 
 @pytest.mark.parametrize("import_url, protected", [
-    ("something.anvil.gi.ucsc.edu", True),
-    ("something-else.anvil.gi.ucsc.edu", True),
-    ("something.anvilproject.org", True),
+    ("service.prod.anvil.gi.ucsc.edu", True),
+    ("service.anvil.gi.ucsc.edu", True),
     ("gen3.biodatacatalyst.nhlbi.nih.gov", True),
     ("something.anvil.edu", False),
     ("something.org", False),

--- a/app/tests/test_new_import.py
+++ b/app/tests/test_new_import.py
@@ -171,11 +171,10 @@ def test_bad_request_when_isUpsert_is_not_boolean(input_value, client):
 user_info = UserInfo("subject-id", "awesomepossum@broadinstitute.org", True)
 
 @pytest.mark.parametrize("import_url, netloc", [
-    ("https://something.anvil.gi.ucsc.edu/manifest/files", 'something.anvil.gi.ucsc.edu'),
-    ("https://something-else.anvil.gi.ucsc.edu/manifest/files", 'something-else.anvil.gi.ucsc.edu'),
-    ("https://anvil.gi.ucsc.edu/manifest/files", 'anvil.gi.ucsc.edu'),
-    ("https://something.anvil.gi.ucsc.edu", 'something.anvil.gi.ucsc.edu'),
-    ("something.anvil.gi.ucsc.edu", None),
+    ("https://storage.googleapis.com/test-bucket/manifest/files", 'storage.googleapis.com'),
+    ("https://test-container.blob.core.windows.net/manifest/files", 'test-container.blob.core.windows.net'),
+    ("https://test-bucket.s3.amazonaws.com/manifest/files", 'test-bucket.s3.amazonaws.com'),
+    ("storage.googleapis.com", None),
 ])
 @pytest.mark.parametrize("file_type_translator", FILETYPE_TRANSLATORS)
 def test_validate_import_url(import_url, netloc, file_type_translator):


### PR DESCRIPTION
Import service only accepts import requests when the URL matches a specific set of domains (or more specifically, netlocs). Currently, this set of domains is hard-coded in new_import.py.

This moves that configuration to app.yaml, where the set of allowed domains can be configured based on the environment in which import service is deployed. Import service will also always accept imports from any GCS bucket, Azure storage container, or S3 bucket.

Also, checking valid netlocs is currently done by checking if the import URL ends with a valid netloc. Thus, if `example.com` is a valid netloc, then import service will accept imports from `example.com`, `subdomain.example.com`, `prefix-example.com`, etc. This changes that behavior to check if the request import URL's netloc exactly matches a configured valid netloc. The old behavior can be opted into by prefixing a valid netloc with `*`. This is used for allowing imports from Azure storage containers and S3 buckets, where the domain is specific to the storage container/bucket.

Finally, this updates the list of valid netlocs for Anvil. Currently, imports are allowed from all domains ending with either `anvil.gi.ucsc.edu` or `anvilproject.org`. This makes it so that, in production, imports are allowed from `service.prod.anvil.gi.ucsc.edu` and in other environments, imports are allowed from `service.anvil.gi.ucsc.edu`. Imports from `anvilproject.org` are no longer accepted.

