### PR TITLE
[AJ-1324] Allow imports from S3 using path style URLs

### DIFF
--- a/app/new_import.py
+++ b/app/new_import.py
@@ -19,7 +19,14 @@ from app.auth.userinfo import UserInfo
 PROTECTED_NETLOCS = ["service.prod.anvil.gi.ucsc.edu", "service.anvil.gi.ucsc.edu", "gen3.biodatacatalyst.nhlbi.nih.gov", "gen3-biodatacatalyst-nhlbi-nih-gov-pfb-export.s3.amazonaws.com", "gen3-theanvil-io-pfb-export.s3.amazonaws.com"]
 
 # Allow downloads from any GCS bucket, Azure storage container, or S3 bucket
-VALID_NETLOCS = ["storage.googleapis.com", "*.core.windows.net", "*.s3.amazonaws.com"]
+VALID_NETLOCS = [
+    "storage.googleapis.com",
+    "*.core.windows.net",
+    # S3 allows multiple URL formats
+    # https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html
+    "s3.amazonaws.com", # path style legacy global endpoint
+    "*.s3.amazonaws.com", # virtual host style legacy global endpoint
+]
 
 # Allow configuration to specify additional netlocs from which imports are allowed.
 additional_valid_netlocs = os.getenv("IMPORT_ALLOWED_NETLOCS")

--- a/app/protected_data.py
+++ b/app/protected_data.py
@@ -23,6 +23,7 @@ def url_patterns_for_s3_bucket(bucket_name: str) -> List[re.Pattern]:
 PROTECTED_URL_PATTERNS: List[re.Pattern] = [
     # AnVIL production
     url_pattern_for_host("service.prod.anvil.gi.ucsc.edu"),
+    *url_patterns_for_s3_bucket("edu-ucsc-gi-platform-anvil-prod-storage-anvilprod.us-east-1"),
     # AnVIL development
     url_pattern_for_host("service.anvil.gi.ucsc.edu"),
     # BioData Catalyst

--- a/app/protected_data.py
+++ b/app/protected_data.py
@@ -1,0 +1,32 @@
+import re
+from typing import List
+
+
+def url_pattern_for_host(hostname: str) -> re.Pattern:
+    """Returns a pattern matching URLs for files on the given hostname and its subdomains."""
+    return re.compile(f"^https://(.+)?{re.escape(hostname)}/")
+
+def url_patterns_for_s3_bucket(bucket_name: str) -> List[re.Pattern]:
+    """
+    Returns patterns matching URLs for files in the given S3 bucket.
+    
+    This returns multiple patterns because S3 supports multiple URL formats.
+    https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html
+    """
+    virtual_host_based_global_endpoint_url = f"https://{bucket_name}.s3.amazonaws.com/"
+    path_based_global_endpoint_url = f"https://s3.amazonaws.com/{bucket_name}/"
+    return [
+        re.compile("^" + re.escape(virtual_host_based_global_endpoint_url)),
+        re.compile("^" + re.escape(path_based_global_endpoint_url)),
+    ]
+
+PROTECTED_URL_PATTERNS: List[re.Pattern] = [
+    # AnVIL production
+    url_pattern_for_host("service.prod.anvil.gi.ucsc.edu"),
+    # AnVIL development
+    url_pattern_for_host("service.anvil.gi.ucsc.edu"),
+    # BioData Catalyst
+    url_pattern_for_host("gen3.biodatacatalyst.nhlbi.nih.gov"),
+    *url_patterns_for_s3_bucket("gen3-biodatacatalyst-nhlbi-nih-gov-pfb-export"),
+    *url_patterns_for_s3_bucket("gen3-theanvil-io-pfb-export"),
+]

--- a/app/tests/test_new_import.py
+++ b/app/tests/test_new_import.py
@@ -193,11 +193,14 @@ def test_validate_import_url(import_url, netloc, file_type_translator):
 @pytest.mark.parametrize("import_url, protected", [
     ("https://service.prod.anvil.gi.ucsc.edu/path/to/file.pfb", True),
     ("https://service.anvil.gi.ucsc.edu/path/to/file.pfb", True),
+    ("https://subdomain.service.anvil.gi.ucsc.edu/path/to/file.pfb", True),
     ("https://gen3.biodatacatalyst.nhlbi.nih.gov/path/to/file.pfb", True),
     ("https://something.anvil.edu/path/to/file.pfb", False),
     ("https://something.org/path/to/file.pfb", False),
     ("https://gen3-biodatacatalyst-nhlbi-nih-gov-pfb-export.s3.amazonaws.com/path/to/file.pfb", True),
-    ("https://gen3-theanvil-io-pfb-export.s3.amazonaws.com/path/to/file.pfb", True)
+    ("https://s3.amazonaws.com/gen3-biodatacatalyst-nhlbi-nih-gov-pfb-export/path/to/file.pfb", True),
+    ("https://gen3-theanvil-io-pfb-export.s3.amazonaws.com/path/to/file.pfb", True),
+    ("https://s3.amazonaws.com/gen3-theanvil-io-pfb-export/path/to/file.pfb", True),
 ])
 def test_is_protected_data_pfb(import_url, protected):
     assert is_protected_data(import_url, "pfb", google_project="test_project", user_info=UserInfo("subject-id", "user@example.com", True)) is protected

--- a/app/tests/test_new_import.py
+++ b/app/tests/test_new_import.py
@@ -201,6 +201,7 @@ def test_validate_import_url(import_url, netloc, file_type_translator):
     ("https://s3.amazonaws.com/gen3-biodatacatalyst-nhlbi-nih-gov-pfb-export/path/to/file.pfb", True),
     ("https://gen3-theanvil-io-pfb-export.s3.amazonaws.com/path/to/file.pfb", True),
     ("https://s3.amazonaws.com/gen3-theanvil-io-pfb-export/path/to/file.pfb", True),
+    ("https://s3.amazonaws.com/edu-ucsc-gi-platform-anvil-prod-storage-anvilprod.us-east-1/path/to/file.pfb", True),
 ])
 def test_is_protected_data_pfb(import_url, protected):
     assert is_protected_data(import_url, "pfb", google_project="test_project", user_info=UserInfo("subject-id", "user@example.com", True)) is protected

--- a/app/tests/test_path_validation.py
+++ b/app/tests/test_path_validation.py
@@ -26,7 +26,8 @@ def good_http_tdr_manifest(monkeypatch, fake_tdr_manifest):
 user_info = UserInfo("subject-id", "awesomepossum@broadinstitute.org", True)
 @pytest.mark.parametrize("netloc", ["storage.googleapis.com",
                                     "test-container.blob.core.windows.net",
-                                    "test-bucket.s3.amazonaws.com"])
+                                    "test-bucket.s3.amazonaws.com",
+                                    "s3.amazonaws.com"])
 @pytest.mark.parametrize("filetype", translate.FILETYPE_TRANSLATORS.keys())
 @pytest.mark.usefixtures("sam_valid_user", "user_has_ws_access", "pubsub_publish", "pubsub_fake_env", "good_http_tdr_manifest")
 def test_default_valid_netlocs(client, netloc, filetype):


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1323

Import service is intended to accept imports from any S3 bucket. However, S3 supports multiple formats of URLs (https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html).

Currently, import service only supports the “virtual host style” “legacy global endpoint” (`https://<bucket>.s3.amazonaws.com/path/to/file`).

The HCA import is attempting to use the “path style” “legacy global endpoint” (`https://s3.amazonaws.com/<bucket>/path/to/file`). This adds support for it.