### PR TITLE
[AJ-1324] Allow configuring restricted buckets

### DIFF
--- a/app.yaml.ctmpl
+++ b/app.yaml.ctmpl
@@ -67,6 +67,7 @@ env_variables:
  RAWLS_PUBSUB_TOPIC: "rawls-async-import-topic-{{$env}}"
 
  IMPORT_ALLOWED_NETLOCS: "{{if eq $env "prod"}}service.prod.anvil.gi.ucsc.edu{{else}}service.anvil.gi.ucsc.edu{{end}},*dev.singlecell.gi.ucsc.edu,*gen3.biodatacatalyst.nhlbi.nih.gov,*service.azul.data.humancellatlas.org"
+ IMPORT_RESTRICTED_SOURCES: "{{if eq $env "prod"}}{{else}}s3://edu-ucsc-gi-platform-anvil-prod-storage-anvilprod.us-east-1{{end}}"
 
 {{end}}{{end}}{{end}}{{end}}{{end}}{{end}}{{end}}{{end}}{{end}}
 

--- a/app/new_import.py
+++ b/app/new_import.py
@@ -74,7 +74,7 @@ def handle(request: flask.Request, ws_ns: str, ws_name: str) -> model.ImportStat
 
     # Refuse imports from restricted sources
     if protected_data.is_restricted_import(import_url):
-        raise exceptions.AuthorizationException("Unable to import data from this source")
+        raise exceptions.AuthorizationException("Unable to import data from this source into this Terra environment")
 
     # Refuse to import protected data into unprotected workspace
     if is_protected_data(import_url, import_filetype, google_project=google_project, user_info=user_info):

--- a/app/new_import.py
+++ b/app/new_import.py
@@ -15,7 +15,7 @@ from urllib.parse import ParseResult, urlparse
 import os
 
 from app.auth.userinfo import UserInfo
-from app.protected_data import PROTECTED_URL_PATTERNS
+from app import protected_data
 
 # Allow downloads from any GCS bucket, Azure storage container, or S3 bucket
 VALID_NETLOCS = [
@@ -71,6 +71,11 @@ def handle(request: flask.Request, ws_ns: str, ws_name: str) -> model.ImportStat
 
     # and validate the input's path
     validate_import_url(import_url, import_filetype, user_info)
+
+    # Refuse imports from restricted sources
+    if protected_data.is_restricted_import(import_url):
+        raise exceptions.AuthorizationException("Unable to import data from this source")
+
     # Refuse to import protected data into unprotected workspace
     if is_protected_data(import_url, import_filetype, google_project=google_project, user_info=user_info):
         if not is_protected_workspace(authorization_domain, bucket_name):
@@ -158,7 +163,7 @@ def is_protected_data(import_url: str, import_filetype: str, *, google_project: 
     and its filetype."""
     
     if import_filetype == "pfb":
-        return any(pattern.match(import_url) for pattern in PROTECTED_URL_PATTERNS)
+        return any(pattern.match(import_url) for pattern in protected_data.PROTECTED_URL_PATTERNS)
 
     elif import_filetype == "tdrexport":
         parsed_url = urlparse(import_url)

--- a/app/protected_data.py
+++ b/app/protected_data.py
@@ -1,3 +1,4 @@
+import os
 import re
 from typing import List
 
@@ -31,3 +32,31 @@ PROTECTED_URL_PATTERNS: List[re.Pattern] = [
     *url_patterns_for_s3_bucket("gen3-biodatacatalyst-nhlbi-nih-gov-pfb-export"),
     *url_patterns_for_s3_bucket("gen3-theanvil-io-pfb-export"),
 ]
+
+def get_restricted_url_patterns() -> List[re.Pattern]:
+    """
+    By default import service allows imports from any S3 or GCS bucket or Azure blob storage container.
+    This allows denying imports from specific S3 buckets. From the IMPORT_RESTRICTED_SOURCES environment
+    variable, it get a list of patterns matching URLs for imports from those sources.
+    
+    IMPORT_RESTRICTED_SOURCES should be a comma separated list where each item is an s3://bucket URL.
+    """
+    restricted_sources_config = os.getenv("IMPORT_RESTRICTED_SOURCES")
+    if not restricted_sources_config:
+        return []
+    
+    restricted_url_patterns: List[re.Pattern] = []
+    restricted_sources = [s.strip() for s in restricted_sources_config.split(",")] 
+    for source in restricted_sources:
+        if source.startswith("s3://"):
+            bucket_name = source[5:]
+            restricted_url_patterns.extend(url_patterns_for_s3_bucket(bucket_name))
+
+    return restricted_url_patterns
+
+
+RESTRICTED_URL_PATTERNS: List[re.Pattern] = get_restricted_url_patterns()
+
+def is_restricted_import(import_url: str) -> bool:
+    """Whether or not an import URL points to a file from a restricted source."""
+    return any(pattern.match(import_url) for pattern in RESTRICTED_URL_PATTERNS)

--- a/app/tests/test_new_import.py
+++ b/app/tests/test_new_import.py
@@ -3,7 +3,7 @@ import pytest
 from unittest import mock
 
 from app.tests import testutils
-from app import new_import
+from app import new_import, protected_data
 from app.util import exceptions
 from app.db import db
 from app.db.model import *
@@ -13,7 +13,6 @@ from app.translate import FILETYPE_TRANSLATORS
 from app.new_import import validate_import_url, is_protected_data, is_protected_workspace
 from app.util.exceptions import InvalidPathException
 from app.auth.userinfo import UserInfo
-from app.protected_data import url_patterns_for_s3_bucket
 
 
 good_json = {"path": f"https://{new_import.VALID_NETLOCS[0]}/some/path", "filetype": "pfb"}
@@ -224,7 +223,7 @@ def test_is_protected_data_tdr(manifest, protected):
 def test_is_protected_workspace(authorization_domain, bucket_name, protected):
     assert is_protected_workspace(authorization_domain, bucket_name) is protected
 
-@mock.patch.object(new_import.protected_data, "RESTRICTED_URL_PATTERNS", url_patterns_for_s3_bucket("test-bucket"))
+@mock.patch.object(new_import.protected_data, "RESTRICTED_URL_PATTERNS", protected_data.url_patterns_for_s3_bucket("test-bucket"))
 @pytest.mark.usefixtures("sam_valid_user", "user_has_ws_access", "pubsub_publish", "pubsub_fake_env")
 def test_restricted_imports(client):
     payload = {"path": "https://s3.amazonaws.com/test-bucket/some/valid/path.pfb", "filetype": "pfb"}

--- a/app/tests/test_protected_data.py
+++ b/app/tests/test_protected_data.py
@@ -1,0 +1,21 @@
+import os
+from unittest import mock
+
+import pytest
+
+from app import protected_data
+
+@mock.patch.dict(os.environ, {"IMPORT_RESTRICTED_SOURCES": "s3://test-bucket-1,s3://test-bucket-2"})
+def test_get_restricted_url_patterns():
+  assert protected_data.get_restricted_url_patterns() == [
+    *protected_data.url_patterns_for_s3_bucket("test-bucket-1"),
+    *protected_data.url_patterns_for_s3_bucket("test-bucket-2"),
+  ]
+
+@mock.patch.object(protected_data, "RESTRICTED_URL_PATTERNS", protected_data.url_patterns_for_s3_bucket("restricted-bucket"))
+@pytest.mark.parametrize("import_url,expected_is_restricted", [
+  ("https://s3.amazonaws.com/restricted-bucket/path/to/file.pfb", True),
+  ("https://s3.amazonaws.com/other-bucket/path/to/file.pfb", False),
+])
+def test_is_restricted_import(import_url, expected_is_restricted):
+  assert protected_data.is_restricted_import(import_url) == expected_is_restricted


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1324

Stacked on #142.

This is part 2 of fixing the UCSC imports. By default, import service accepts imports from any GCS or S3 bucket or Azure storage container. After UCSC's changes, we need to support importing AnVIL data from S3 URLs. AnVIL data has the additional requirement that we block imports of production AnVIL data URLs into non-production Terra environments.

This adds an environment variable that allows configuring "restricted" S3 buckets, where imports from those buckets should be blocked. It configures the UCSC AnVIL bucket as a restricted source for non-production environments.