### PR TITLE
[AJ-1311] Block cross-platform TDR imports

### DIFF
--- a/app/external/cloud_platform.py
+++ b/app/external/cloud_platform.py
@@ -1,0 +1,4 @@
+from typing import Literal, Union
+
+
+CloudPlatform = Union[Literal["azure"], Literal["gcp"]]

--- a/app/external/rawls.py
+++ b/app/external/rawls.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Optional, Set
 
 import requests
+from app.external.cloud_platform import CloudPlatform
 from app.util.exceptions import ISvcException
 
 
@@ -11,18 +12,25 @@ from app.util.exceptions import ISvcException
 class RawlsWorkspaceResponse:
      workspace_id: str
      google_project: str
+     cloud_platform: CloudPlatform
      authorization_domain: Optional[Set[str]] = None
      bucket_name: Optional[str] = None
 
 
 def get_rawls_workspace_info(workspace_namespace: str, workspace_name: str, bearer_token: str) -> RawlsWorkspaceResponse:
     resp = requests.get(
-        f"{os.environ.get('RAWLS_URL')}/api/workspaces/{workspace_namespace}/{workspace_name}?fields=workspace.workspaceId,workspace.googleProject,workspace.authorizationDomain,workspace.bucketName",
+        f"{os.environ.get('RAWLS_URL')}/api/workspaces/{workspace_namespace}/{workspace_name}?fields=workspace.workspaceId,workspace.googleProject,workspace.authorizationDomain,workspace.bucketName,workspace.cloudPlatform",
         headers={"Authorization": bearer_token})
 
     if resp.ok:
         jso = resp.json()
-        return RawlsWorkspaceResponse(workspace_id=jso["workspace"]["workspaceId"], google_project=jso["workspace"]["googleProject"], authorization_domain=jso["workspace"].get("authorizationDomain"), bucket_name=jso["workspace"].get("bucketName"))
+        return RawlsWorkspaceResponse(
+            workspace_id=jso["workspace"]["workspaceId"],
+            google_project=jso["workspace"]["googleProject"],
+            cloud_platform=jso["workspace"]["cloudPlatform"].lower(),
+            authorization_domain=jso["workspace"].get("authorizationDomain"),
+            bucket_name=jso["workspace"].get("bucketName")
+        )
     else:
         # just pass the error upwards
         workspace_dict = { 'workspace': { 'namespace': workspace_namespace, 'name': workspace_name} }

--- a/app/external/tdr_model.py
+++ b/app/external/tdr_model.py
@@ -4,11 +4,13 @@ from typing import Any, List, Optional
 
 from pydantic import BaseModel, Field
 
+from app.external.cloud_platform import CloudPlatform
+
 
 class StorageItem(BaseModel):
     region: str
     cloudResource: str
-    cloudPlatform: str
+    cloudPlatform: CloudPlatform
 
 
 class Dataset(BaseModel):

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -122,7 +122,7 @@ def sam_valid_pet_key(monkeypatch):
 def user_has_ws_access(monkeypatch):
     """Makes us think that the user has access to the workspace in Rawls."""
     monkeypatch.setattr("app.auth.user_auth.workspace_uuid_and_project_with_auth",
-                        mock.MagicMock(return_value=RawlsWorkspaceResponse("some-uuid", "some-project", set(), "fc-secure-12345678-a901-23b4-c5d6-7ef8a90b1cd2")))
+                        mock.MagicMock(return_value=RawlsWorkspaceResponse("some-uuid", "some-project", "gcp", set(), "fc-secure-12345678-a901-23b4-c5d6-7ef8a90b1cd2")))
 
 
 @pytest.fixture(scope="function")

--- a/app/tests/test_new_import.py
+++ b/app/tests/test_new_import.py
@@ -116,7 +116,7 @@ def test_user_cant_write_to_workspace(client):
 # returns ok when asked if the user has "write", but returns 456 when asked if the user has "read_policies"
 def mock_auth_for_read_policies(workspace_ns: str, workspace_name: str, bearer_token: str, sam_action: str = "read") -> RawlsWorkspaceResponse:
     if sam_action == "write":
-        return RawlsWorkspaceResponse(workspace_id="workspaceId", google_project="googleProject")
+        return RawlsWorkspaceResponse(workspace_id="workspaceId", google_project="googleProject", cloud_platform="gcp")
     elif sam_action == "read_policies":
         # specify 456 status code to disambiguate the read_policies response from any other response code
         raise exceptions.ISvcException("user does not have read_policies", 456)

--- a/app/tests/test_new_import.py
+++ b/app/tests/test_new_import.py
@@ -233,3 +233,17 @@ def test_restricted_imports(client):
     payload = {"path": "https://s3.amazonaws.com/test-bucket/some/valid/path.pfb", "filetype": "pfb"}
     resp = client.post('/namespace/name/imports', json=payload, headers=good_headers)
     assert resp.status_code == 403
+
+@pytest.mark.parametrize("manifest,workspace_cloud_platform",[
+    ("test_tdr_response_gcp.json", "azure"),
+    ("test_tdr_response_azure.json", "gcp"),
+])
+@pytest.mark.usefixtures("sam_valid_user", "pubsub_publish", "pubsub_fake_env")
+def test_blocks_cross_platform_tdr_imports(monkeypatch, client, manifest, workspace_cloud_platform):
+    monkeypatch.setattr("app.auth.user_auth.workspace_uuid_and_project_with_auth",
+                        mock.MagicMock(return_value=RawlsWorkspaceResponse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", "some-project", workspace_cloud_platform, set(), "fc-11111111-2222-3333-4444-555555555555")))
+    monkeypatch.setattr("app.new_import.http.http_as_filelike", mock.MagicMock(return_value=open(f"app/tests/resources/{manifest}", "rb")))
+
+    resp = client.post('/mynamespace/myname/imports', json=good_tdr_json, headers=good_headers)
+    assert resp.status_code == 403
+    assert resp.text == "Unable to import TDR data across cloud platforms"

--- a/app/tests/test_rawls.py
+++ b/app/tests/test_rawls.py
@@ -17,8 +17,8 @@ def test_get_workspace_uuid():
             rawls.get_rawls_workspace_info("a", "a", "a")
 
     # rawls returns ok with good json, parse it out
-    with testutils.patch_request("app.external.rawls", "get", status_code = 200, json={"workspace" : {"workspaceId" : "the-uuid", "googleProject": "proj"}}):
-        assert rawls.get_rawls_workspace_info("a", "a", "a") == RawlsWorkspaceResponse("the-uuid", "proj")
+    with testutils.patch_request("app.external.rawls", "get", status_code = 200, json={"workspace" : {"workspaceId" : "the-uuid", "googleProject": "proj", "cloudPlatform": "Gcp"}}):
+        assert rawls.get_rawls_workspace_info("a", "a", "a") == RawlsWorkspaceResponse("the-uuid", "proj", "gcp")
 
 
 def test_check_workspace_iam_action():

--- a/app/tests/test_user_auth.py
+++ b/app/tests/test_user_auth.py
@@ -49,28 +49,27 @@ def test_workspace_uuid():
             mock_rawls_getaction.assert_not_called()
 
     # rawls returns workspace id, action is "read", no need to do auth check
-    with mock.patch.object(app.external.rawls, "get_rawls_workspace_info", return_value = RawlsWorkspaceResponse("the-uuid", "proj")):
+    with mock.patch.object(app.external.rawls, "get_rawls_workspace_info", return_value = RawlsWorkspaceResponse("the-uuid", "proj", "gcp")):
         with mock.patch.object(app.external.rawls, "check_workspace_iam_action") as mock_rawls_getaction:
-            assert user_auth.workspace_uuid_and_project_with_auth("wsns", "wsn", "bearer", "read") == RawlsWorkspaceResponse("the-uuid", "proj")
+            assert user_auth.workspace_uuid_and_project_with_auth("wsns", "wsn", "bearer", "read") == RawlsWorkspaceResponse("the-uuid", "proj", "gcp")
             mock_rawls_getaction.assert_not_called()
 
     # rawls returns workspace id, action is write, auth check called, returns non-OK status
-    with mock.patch.object(app.external.rawls, "get_rawls_workspace_info", return_value = RawlsWorkspaceResponse("the-uuid", "proj")):
+    with mock.patch.object(app.external.rawls, "get_rawls_workspace_info", return_value = RawlsWorkspaceResponse("the-uuid", "proj", "gcp")):
         with mock.patch.object(app.external.rawls, "check_workspace_iam_action", side_effect = exceptions.ISvcException("bork", 500)) as mock_rawls_getaction:
             with pytest.raises(exceptions.ISvcException):
                 user_auth.workspace_uuid_and_project_with_auth("wsns", "wsn", "bearer", "write")
             mock_rawls_getaction.assert_called_once()
 
     # rawls returns workspace id, action is write, auth check called, returns false: you can't do this action
-    with mock.patch.object(app.external.rawls, "get_rawls_workspace_info", return_value = RawlsWorkspaceResponse("the-uuid", "proj")):
+    with mock.patch.object(app.external.rawls, "get_rawls_workspace_info", return_value = RawlsWorkspaceResponse("the-uuid", "proj", "gcp")):
         with mock.patch.object(app.external.rawls, "check_workspace_iam_action", return_value = False) as mock_rawls_getaction:
             with pytest.raises(exceptions.AuthorizationException):
                 user_auth.workspace_uuid_and_project_with_auth("wsns", "wsn", "bearer", "write")
             mock_rawls_getaction.assert_called_once()
 
     # rawls returns workspace id, action is write, auth check called, returns true: hooray!
-    with mock.patch.object(app.external.rawls, "get_rawls_workspace_info", return_value = RawlsWorkspaceResponse("the-uuid", "proj")):
+    with mock.patch.object(app.external.rawls, "get_rawls_workspace_info", return_value = RawlsWorkspaceResponse("the-uuid", "proj", "gcp")):
         with mock.patch.object(app.external.rawls, "check_workspace_iam_action", return_value = True) as mock_rawls_getaction:
-            assert user_auth.workspace_uuid_and_project_with_auth("wsns", "wsn", "bearer", "write") == RawlsWorkspaceResponse("the-uuid", "proj")
+            assert user_auth.workspace_uuid_and_project_with_auth("wsns", "wsn", "bearer", "write") == RawlsWorkspaceResponse("the-uuid", "proj", "gcp")
             mock_rawls_getaction.assert_called_once()
-


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1311

Until the story for egress costs is figured out, we want to block imports of TDR snapshots across cloud platforms (GCP snapshot => Azure workspace, Azure snapshot => GCP workspace). This adds a check for cross-cloud platform imports to the initial import request validation.