### PR TITLE
DR-3210 Allow imports from google signed urls from TDR

### DIFF
--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -67,8 +67,12 @@ def fake_import() -> Iterator[model.Import]:
     yield model.Import("aa", "aa", "uuid", "project", "aa@aa.aa", "gs://aa/aa", "pfb")
 
 @pytest.fixture(scope="function")
-def fake_import_tdr_manifest_gcp() -> Iterator[model.Import]:
+def fake_import_tdr_manifest_gcp_gs() -> Iterator[model.Import]:
     yield model.Import("bb", "bb", "uuid2", "project2", "bb@bb.bb", "gs://bb/bb", "tdrexport")
+
+@pytest.fixture(scope="function")
+def fake_import_tdr_manifest_gcp_https() -> Iterator[model.Import]:
+    yield model.Import("bb", "bb", "uuid2", "project2", "bb@bb.bb", "https://storage.googleapis.com/bb/bb", "tdrexport")
 
 @pytest.fixture(scope="function")
 def fake_import_tdr_manifest_azure() -> Iterator[model.Import]:

--- a/app/tests/resources/test_tdr_response_gcp_https.json
+++ b/app/tests/resources/test_tdr_response_gcp_https.json
@@ -1,0 +1,958 @@
+{
+  "snapshot": {
+    "id": "9516afec-583f-11ec-bf63-0242ac130002",
+    "name": "unit_test_snapshot",
+    "description": "Exemplar snapshot for unit testing data",
+    "createdDate": "2021-04-05T07:07:08.654321Z",
+    "source": [
+      {
+        "dataset": {
+          "id": "d70f8266-583f-11ec-bf63-0242ac130002",
+          "name": "unit_test_dataset",
+          "description": "Exemplar dataset for unit testing data",
+          "defaultProfileId": "e55435f6-583f-11ec-bf63-0242ac130002",
+          "createdDate": "2021-01-02T03:04:05.654321Z",
+          "storage": [
+            {
+              "region": "us-central1",
+              "cloudResource": "bigquery",
+              "cloudPlatform": "gcp"
+            },
+            {
+              "region": "us-east4",
+              "cloudResource": "firestore",
+              "cloudPlatform": "gcp"
+            },
+            {
+              "region": "us-central1",
+              "cloudResource": "bucket",
+              "cloudPlatform": "gcp"
+            }
+          ]
+        },
+        "asset": null
+      }
+    ],
+    "tables": [
+      {
+        "name": "messages",
+        "columns": [
+          {
+            "name": "messages_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 0
+      },
+      {
+        "name": "location",
+        "columns": [
+          {
+            "name": "location_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 0
+      },
+      {
+        "name": "cost",
+        "columns": [
+          {
+            "name": "cost_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 82
+      },
+      {
+        "name": "product",
+        "columns": [
+          {
+            "name": "product_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 0
+      },
+      {
+        "name": "footnote",
+        "columns": [
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "file_id",
+            "datatype": "fileref",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "footnote_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "descriptor",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 23
+      },
+      {
+        "name": "diagram",
+        "columns": [
+          {
+            "name": "diagram_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 0
+      },
+      {
+        "name": "graphic",
+        "columns": [
+          {
+            "name": "graphic_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 0
+      },
+      {
+        "name": "sequence",
+        "columns": [
+          {
+            "name": "sequence_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 21
+      },
+      {
+        "name": "project",
+        "columns": [
+          {
+            "name": "project_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 1
+      },
+      {
+        "name": "person",
+        "columns": [
+          {
+            "name": "person_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 1643
+      },
+      {
+        "name": "signature",
+        "columns": [
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "file_id",
+            "datatype": "fileref",
+            "array_of": false
+          },
+          {
+            "name": "signature_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "descriptor",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 0
+      },
+      {
+        "name": "photo",
+        "columns": [
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "file_id",
+            "datatype": "fileref",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "photo_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "descriptor",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 0
+      },
+      {
+        "name": "regulation",
+        "columns": [
+          {
+            "name": "regulation_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 0
+      },
+      {
+        "name": "annotation",
+        "columns": [
+          {
+            "name": "annotation_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 0
+      },
+      {
+        "name": "lab",
+        "columns": [
+          {
+            "name": "lab_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 0
+      },
+      {
+        "name": "edges",
+        "columns": [
+          {
+            "name": "edges_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "project_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 221
+      },
+      {
+        "name": "xray",
+        "columns": [
+          {
+            "name": "xray_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "file_id",
+            "datatype": "fileref",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "descriptor",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 0
+      },
+      {
+        "name": "test",
+        "columns": [
+          {
+            "name": "test_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 1
+      },
+      {
+        "name": "vial",
+        "columns": [
+          {
+            "name": "vial_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 1
+      },
+      {
+        "name": "process",
+        "columns": [
+          {
+            "name": "process_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 9876
+      },
+      {
+        "name": "test_result",
+        "columns": [
+          {
+            "name": "test_result_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 0
+      },
+      {
+        "name": "room",
+        "columns": [
+          {
+            "name": "room_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 0
+      },
+      {
+        "name": "chemical",
+        "columns": [
+          {
+            "name": "chemical_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 2345
+      },
+      {
+        "name": "letter",
+        "columns": [
+          {
+            "name": "letter_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 0
+      },
+      {
+        "name": "species",
+        "columns": [
+          {
+            "name": "species_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 808
+      },
+      {
+        "name": "reading",
+        "columns": [
+          {
+            "name": "reading_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 1
+      },
+      {
+        "name": "genome",
+        "columns": [
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "file_id",
+            "datatype": "fileref",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "genome_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "descriptor",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 2097
+      }
+    ],
+    "relationships": [
+      {
+        "name": "from_edges.project_id_to_project.project_id",
+        "from": {
+          "table": "edges",
+          "column": "project_id"
+        },
+        "to": {
+          "table": "project",
+          "column": "project_id"
+        }
+      }
+    ],
+    "profileId": "bff61446-583f-11ec-bf63-0242ac130002",
+    "dataProject": "my-project",
+    "accessInformation": null
+  },
+  "format": {
+    "parquet": {
+      "location": {
+        "tables": [
+          {
+            "name": "messages",
+            "paths": [
+              "https://storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/messages/messages-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "location",
+            "paths": [
+              "https://storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/location/location-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "cost",
+            "paths": [
+              "https://storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/cost/cost-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "product",
+            "paths": [
+              "https://storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/product/product-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "footnote",
+            "paths": [
+              "https://storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/footnote/footnote-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "diagram",
+            "paths": [
+              "https://storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/diagram/diagram-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "graphic",
+            "paths": [
+              "https://storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/graphic/graphic-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "sequence",
+            "paths": [
+              "https://storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/sequence/sequence-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "project",
+            "paths": [
+              "https://storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/project/project-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "person",
+            "paths": [
+              "https://storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/person/person-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "signature",
+            "paths": [
+              "https://storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/signature/signature-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "photo",
+            "paths": [
+              "https://storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/photo/photo-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "regulation",
+            "paths": [
+              "https://storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/regulation/regulation-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "annotation",
+            "paths": [
+              "https://storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/annotation/annotation-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "lab",
+            "paths": [
+              "https://storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/lab/lab-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "edges",
+            "paths": [
+              "https://storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/edges/edges-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX",
+              "https://storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/edges/edges-000000000001.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "xray",
+            "paths": [
+              "https://storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/xray/xray-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "test",
+            "paths": [
+              "https://storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/test/test-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "vial",
+            "paths": [
+              "https://storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/vial/vial-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "process",
+            "paths": [
+              "https://storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/process/process-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "test_result",
+            "paths": [
+              "https://storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/test_result/test_result-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "room",
+            "paths": [
+              "https://storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/room/room-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "chemical",
+            "paths": [
+              "https://storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/chemical/chemical-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "letter",
+            "paths": [
+              "https://storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/letter/letter-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "species",
+            "paths": [
+              "https://storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/species/species-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "reading",
+            "paths": [
+              "https://storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/reading/reading-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "genome",
+            "paths": [
+              "https://storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/genome/genome-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          }
+        ]
+      },
+      "manifest": "https://storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/manifest.json?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+    },
+    "workspace": null
+  }
+}

--- a/app/tests/resources/test_tdr_response_gcp_https_invalid_domain.json
+++ b/app/tests/resources/test_tdr_response_gcp_https_invalid_domain.json
@@ -1,0 +1,958 @@
+{
+  "snapshot": {
+    "id": "9516afec-583f-11ec-bf63-0242ac130002",
+    "name": "unit_test_snapshot",
+    "description": "Exemplar snapshot for unit testing data",
+    "createdDate": "2021-04-05T07:07:08.654321Z",
+    "source": [
+      {
+        "dataset": {
+          "id": "d70f8266-583f-11ec-bf63-0242ac130002",
+          "name": "unit_test_dataset",
+          "description": "Exemplar dataset for unit testing data",
+          "defaultProfileId": "e55435f6-583f-11ec-bf63-0242ac130002",
+          "createdDate": "2021-01-02T03:04:05.654321Z",
+          "storage": [
+            {
+              "region": "us-central1",
+              "cloudResource": "bigquery",
+              "cloudPlatform": "gcp"
+            },
+            {
+              "region": "us-east4",
+              "cloudResource": "firestore",
+              "cloudPlatform": "gcp"
+            },
+            {
+              "region": "us-central1",
+              "cloudResource": "bucket",
+              "cloudPlatform": "gcp"
+            }
+          ]
+        },
+        "asset": null
+      }
+    ],
+    "tables": [
+      {
+        "name": "messages",
+        "columns": [
+          {
+            "name": "messages_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 0
+      },
+      {
+        "name": "location",
+        "columns": [
+          {
+            "name": "location_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 0
+      },
+      {
+        "name": "cost",
+        "columns": [
+          {
+            "name": "cost_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 82
+      },
+      {
+        "name": "product",
+        "columns": [
+          {
+            "name": "product_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 0
+      },
+      {
+        "name": "footnote",
+        "columns": [
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "file_id",
+            "datatype": "fileref",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "footnote_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "descriptor",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 23
+      },
+      {
+        "name": "diagram",
+        "columns": [
+          {
+            "name": "diagram_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 0
+      },
+      {
+        "name": "graphic",
+        "columns": [
+          {
+            "name": "graphic_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 0
+      },
+      {
+        "name": "sequence",
+        "columns": [
+          {
+            "name": "sequence_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 21
+      },
+      {
+        "name": "project",
+        "columns": [
+          {
+            "name": "project_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 1
+      },
+      {
+        "name": "person",
+        "columns": [
+          {
+            "name": "person_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 1643
+      },
+      {
+        "name": "signature",
+        "columns": [
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "file_id",
+            "datatype": "fileref",
+            "array_of": false
+          },
+          {
+            "name": "signature_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "descriptor",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 0
+      },
+      {
+        "name": "photo",
+        "columns": [
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "file_id",
+            "datatype": "fileref",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "photo_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "descriptor",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 0
+      },
+      {
+        "name": "regulation",
+        "columns": [
+          {
+            "name": "regulation_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 0
+      },
+      {
+        "name": "annotation",
+        "columns": [
+          {
+            "name": "annotation_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 0
+      },
+      {
+        "name": "lab",
+        "columns": [
+          {
+            "name": "lab_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 0
+      },
+      {
+        "name": "edges",
+        "columns": [
+          {
+            "name": "edges_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "project_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 221
+      },
+      {
+        "name": "xray",
+        "columns": [
+          {
+            "name": "xray_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "file_id",
+            "datatype": "fileref",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "descriptor",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 0
+      },
+      {
+        "name": "test",
+        "columns": [
+          {
+            "name": "test_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 1
+      },
+      {
+        "name": "vial",
+        "columns": [
+          {
+            "name": "vial_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 1
+      },
+      {
+        "name": "process",
+        "columns": [
+          {
+            "name": "process_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 9876
+      },
+      {
+        "name": "test_result",
+        "columns": [
+          {
+            "name": "test_result_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 0
+      },
+      {
+        "name": "room",
+        "columns": [
+          {
+            "name": "room_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 0
+      },
+      {
+        "name": "chemical",
+        "columns": [
+          {
+            "name": "chemical_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 2345
+      },
+      {
+        "name": "letter",
+        "columns": [
+          {
+            "name": "letter_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 0
+      },
+      {
+        "name": "species",
+        "columns": [
+          {
+            "name": "species_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 808
+      },
+      {
+        "name": "reading",
+        "columns": [
+          {
+            "name": "reading_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 1
+      },
+      {
+        "name": "genome",
+        "columns": [
+          {
+            "name": "content",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "file_id",
+            "datatype": "fileref",
+            "array_of": false
+          },
+          {
+            "name": "version",
+            "datatype": "timestamp",
+            "array_of": false
+          },
+          {
+            "name": "genome_id",
+            "datatype": "string",
+            "array_of": false
+          },
+          {
+            "name": "descriptor",
+            "datatype": "string",
+            "array_of": false
+          }
+        ],
+        "primaryKey": null,
+        "partitionMode": "none",
+        "datePartitionOptions": null,
+        "intPartitionOptions": null,
+        "rowCount": 2097
+      }
+    ],
+    "relationships": [
+      {
+        "name": "from_edges.project_id_to_project.project_id",
+        "from": {
+          "table": "edges",
+          "column": "project_id"
+        },
+        "to": {
+          "table": "project",
+          "column": "project_id"
+        }
+      }
+    ],
+    "profileId": "bff61446-583f-11ec-bf63-0242ac130002",
+    "dataProject": "my-project",
+    "accessInformation": null
+  },
+  "format": {
+    "parquet": {
+      "location": {
+        "tables": [
+          {
+            "name": "messages",
+            "paths": [
+              "https://bad.storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/messages/messages-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "location",
+            "paths": [
+              "https://bad.storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/location/location-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "cost",
+            "paths": [
+              "https://bad.storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/cost/cost-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "product",
+            "paths": [
+              "https://bad.storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/product/product-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "footnote",
+            "paths": [
+              "https://bad.storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/footnote/footnote-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "diagram",
+            "paths": [
+              "https://bad.storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/diagram/diagram-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "graphic",
+            "paths": [
+              "https://bad.storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/graphic/graphic-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "sequence",
+            "paths": [
+              "https://bad.storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/sequence/sequence-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "project",
+            "paths": [
+              "https://bad.storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/project/project-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "person",
+            "paths": [
+              "https://bad.storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/person/person-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "signature",
+            "paths": [
+              "https://bad.storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/signature/signature-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "photo",
+            "paths": [
+              "https://bad.storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/photo/photo-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "regulation",
+            "paths": [
+              "https://bad.storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/regulation/regulation-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "annotation",
+            "paths": [
+              "https://bad.storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/annotation/annotation-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "lab",
+            "paths": [
+              "https://bad.storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/lab/lab-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "edges",
+            "paths": [
+              "https://bad.storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/edges/edges-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX",
+              "https://bad.storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/edges/edges-000000000001.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "xray",
+            "paths": [
+              "https://bad.storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/xray/xray-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "test",
+            "paths": [
+              "https://bad.storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/test/test-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "vial",
+            "paths": [
+              "https://bad.storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/vial/vial-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "process",
+            "paths": [
+              "https://bad.storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/process/process-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "test_result",
+            "paths": [
+              "https://bad.storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/test_result/test_result-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "room",
+            "paths": [
+              "https://bad.storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/room/room-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "chemical",
+            "paths": [
+              "https://bad.storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/chemical/chemical-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "letter",
+            "paths": [
+              "https://bad.storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/letter/letter-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "species",
+            "paths": [
+              "https://bad.storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/species/species-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "reading",
+            "paths": [
+              "https://bad.storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/reading/reading-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          },
+          {
+            "name": "genome",
+            "paths": [
+              "https://bad.storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/genome/genome-000000000000.parquet?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+            ]
+          }
+        ]
+      },
+      "manifest": "https://bad.storage.googleapis.com/my-project-snapshot-export-bucket/feKB6na2Ta2EI5xZDwCqjA/manifest.json?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-sa%40tdr_project.iam.gserviceaccount.com%2F20230926%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20230926T174044Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=researcher%40gmail.com&X-Goog-Signature=XXX"
+    },
+    "workspace": null
+  }
+}

--- a/app/tests/test_sync_permissions.py
+++ b/app/tests/test_sync_permissions.py
@@ -4,16 +4,16 @@ from app.db import model
 from app.translators.sync_permissions import sync_permissions, sync_permissions_if_necessary
 
 
-def test_sync_permissions_for_tdr_snapshot(fake_import_tdr_manifest_gcp: model.Import):
-    finished_import = deepcopy(fake_import_tdr_manifest_gcp)
+def test_sync_permissions_for_tdr_snapshot(fake_import_tdr_manifest_gcp_gs: model.Import):
+    finished_import = deepcopy(fake_import_tdr_manifest_gcp_gs)
     finished_import.snapshot_id = "12_34"
     finished_import.is_tdr_sync_required = True
     with mock.patch("app.translators.sync_permissions.sync_permissions") as mock_sync:
         sync_permissions_if_necessary(finished_import, model.ImportStatus.Done)
         mock_sync.assert_called_once()
 
-def test_no_sync_for_tdr_snapshot_if_not_required(fake_import_tdr_manifest_gcp: model.Import):
-    finished_import = deepcopy(fake_import_tdr_manifest_gcp)
+def test_no_sync_for_tdr_snapshot_if_not_required(fake_import_tdr_manifest_gcp_gs: model.Import):
+    finished_import = deepcopy(fake_import_tdr_manifest_gcp_gs)
     finished_import.snapshot_id = "12_34"
     finished_import.is_tdr_sync_required = False
     with mock.patch("app.translators.sync_permissions.sync_permissions") as mock_sync:
@@ -26,19 +26,19 @@ def test_no_sync_for_pfb(fake_import: model.Import):
         sync_permissions_if_necessary(finished_import, model.ImportStatus.Done)
         mock_sync.assert_not_called()
 
-def test_no_sync_if_snapshot_import_not_completed(fake_import_tdr_manifest_gcp: model.Import):
-    finished_import = deepcopy(fake_import_tdr_manifest_gcp)
+def test_no_sync_if_snapshot_import_not_completed(fake_import_tdr_manifest_gcp_gs: model.Import):
+    finished_import = deepcopy(fake_import_tdr_manifest_gcp_gs)
     finished_import.snapshot_id = "12_34"
     with mock.patch("app.translators.sync_permissions.sync_permissions") as mock_sync:
         sync_permissions_if_necessary(finished_import, model.ImportStatus.Upserting)
         mock_sync.assert_not_called()
 
-def test_all_readers_are_synced(fake_import_tdr_manifest_gcp: model.Import):
+def test_all_readers_are_synced(fake_import_tdr_manifest_gcp_gs: model.Import):
     with mock.patch("app.external.sam.admin_get_pet_auth_header") as mock_token:
         mock_token.return_value = "fake_token"
         with mock.patch("app.external.sam.add_child_policy_member") as mock_update_policy:
-            sync_permissions(fake_import_tdr_manifest_gcp, "12_34")
+            sync_permissions(fake_import_tdr_manifest_gcp_gs, "12_34")
 
-            mock_token.assert_called_once_with(fake_import_tdr_manifest_gcp.workspace_google_project, fake_import_tdr_manifest_gcp.submitter)
+            mock_token.assert_called_once_with(fake_import_tdr_manifest_gcp_gs.workspace_google_project, fake_import_tdr_manifest_gcp_gs.submitter)
             mock_update_policy.assert_called_with("datasnapshot", "12_34", "reader", "workspace", "uuid2", "project-owner", "fake_token")
             assert mock_update_policy.call_count == 4

--- a/app/translators/tdr_manifest_to_rawls.py
+++ b/app/translators/tdr_manifest_to_rawls.py
@@ -98,14 +98,14 @@ class ParquetTranslator:
             bucket = parsedurl.netloc
             path = parsedurl.path
             with gcs.open_file(self.import_details.workspace_google_project, bucket, path, self.import_details.submitter, self.auth_key) as pqfile:
-                return self.translate_parquet_file_to_entities(pqfile, False, ref_only)
+                return self.translate_parquet_file_to_entities(pqfile, is_azure=False, ref_only=ref_only)
         elif (parsedurl.scheme == 'https'):
             hostname = parsedurl.netloc
             if not (hostname.endswith(VALID_AZURE_DOMAIN) or hostname == GOOGLE_STORAGE_DOMAIN):
                 logging.error(f"unsupported domain in url {self.filelocation} provided")
                 raise exceptions.InvalidPathException(self.filelocation, user_info, "Unsupported domain")
             with http.http_as_filelike(self.filelocation) as pqfile:
-                return self.translate_parquet_file_to_entities(pqfile, hostname.endswith(VALID_AZURE_DOMAIN), ref_only)
+                return self.translate_parquet_file_to_entities(pqfile, is_azure=hostname.endswith(VALID_AZURE_DOMAIN), ref_only=ref_only)
         else:
             logging.error(f"unsupported scheme {parsedurl.scheme} provided")
             raise exceptions.InvalidPathException(self.filelocation, user_info, "Unsupported scheme")

--- a/app/util/exceptions.py
+++ b/app/util/exceptions.py
@@ -53,6 +53,10 @@ class FileTooBigToDownload(ISvcException):
         """Thrown when we detect a file is dangerously large."""
         super().__init__(message, 413)
 
+class InvalidFileUrl(ISvcException):
+    def __init__(self, message: str = "The file URL was invalid. It is possible that the URL has expired"):
+        """Thrown when we detect a file URL is invalid.  Likely cause is an expired signed URL"""
+        super().__init__(message, 400)
 
 class InvalidPathException(ISvcException):
     def __init__(self, import_url: Optional[str], user_info: UserInfo, hint: str):

--- a/app/util/exceptions.py
+++ b/app/util/exceptions.py
@@ -54,7 +54,7 @@ class FileTooBigToDownload(ISvcException):
         super().__init__(message, 413)
 
 class InvalidFileUrl(ISvcException):
-    def __init__(self, message: str = "The file URL was invalid. It is possible that the URL has expired"):
+    def __init__(self, message: str = "The file URL was invalid. It is possible that the URL has expired."):
         """Thrown when we detect a file URL is invalid.  Likely cause is an expired signed URL"""
         super().__init__(message, 400)
 

--- a/app/util/http.py
+++ b/app/util/http.py
@@ -5,7 +5,7 @@ from contextlib import contextmanager
 from typing import IO, Iterator
 
 from app.constants import TWO_GB_IN_BYTES
-from app.util.exceptions import FileTooBigToDownload
+from app.util.exceptions import FileTooBigToDownload, InvalidFileUrl
 
 BYTE_RANGE = "0-0"
 
@@ -23,7 +23,10 @@ def http_as_filelike(url: str, file_limit_bytes: int = TWO_GB_IN_BYTES) -> Itera
     content_range = http_response.headers.get('Content-Range')
     if http_response.status_code != 206:
         logging.error(f"Content-Range header unexpectedly returned response code {http_response.status_code} for {url}")
-        raise FileTooBigToDownload
+        if http_response.status_code == 400:
+            raise InvalidFileUrl
+        else:
+            raise FileTooBigToDownload
     if content_range is None:
         logging.error(f"No Content-Range header provided from {url} we won't download")
         raise FileTooBigToDownload


### PR DESCRIPTION
We've seen issues with permission propagation when importing from `gs://` paths.  That's super annoying! This PR allows manifests and parquet files in TDR exports to be signed URLs.  The only thing here is that the urls might expire but that seems more tractable than not knowing when the permissions will become available.  Also, this copies a pattern that we are already using for Azure files (if we ever decide to re-allow importing an azure snapshot into a Google workspace)

A couple of drive-bys:
- Because the likelihood of expiring links, we no longer throw a `FileTooBigToDownload` error when accessing a file via https throws a 400.  We now throw an `InvalidFileUrl` (a little vague but not outright incorrect)
- Refactored some unit tests to be able to have more parameterized tests