### PR TITLE
[AJ-1354] Return 400 instead of 403 when import is blocked

### DIFF
--- a/app/new_import.py
+++ b/app/new_import.py
@@ -75,19 +75,19 @@ def handle(request: flask.Request, ws_ns: str, ws_name: str) -> model.ImportStat
 
     # Refuse imports from restricted sources
     if protected_data.is_restricted_import(import_url):
-        raise exceptions.AuthorizationException("Unable to import data from this source into this Terra environment")
+        raise exceptions.ForbiddenImportException(import_url, user_info, "Unable to import data from this source into this Terra environment")
 
     # Refuse to import protected data into unprotected workspace
     if import_filetype == "pfb":
         if is_protected_pfb(import_url) and not is_protected_workspace(authorization_domain, bucket_name):
-            raise exceptions.AuthorizationException("Unable to import protected data into an unprotected workspace")
+            raise exceptions.ForbiddenImportException(import_url, user_info, "Unable to import protected data into an unprotected workspace")
     elif import_filetype == "tdrexport":
         manifest = load_tdr_manifest(import_url, google_project=google_project, user_info=user_info)
         if is_protected_snapshot(manifest) and not is_protected_workspace(authorization_domain, bucket_name):
-            raise exceptions.AuthorizationException("Unable to import protected data into an unprotected workspace")
+            raise exceptions.ForbiddenImportException(import_url, user_info, "Unable to import protected data into an unprotected workspace")
 
         if not all_sources_on_cloud_platform(manifest, workspace.cloud_platform):
-            raise exceptions.AuthorizationException("Unable to import TDR data across cloud platforms")
+            raise exceptions.ForbiddenImportException(import_url, user_info, "Unable to import TDR data across cloud platforms")
 
     # parse is_upsert from a str into a bool
     is_upsert = str(import_is_upsert).strip().lower() == "true"

--- a/app/tests/test_new_import.py
+++ b/app/tests/test_new_import.py
@@ -232,7 +232,7 @@ def test_is_protected_workspace(authorization_domain, bucket_name, protected):
 def test_restricted_imports(client):
     payload = {"path": "https://s3.amazonaws.com/test-bucket/some/valid/path.pfb", "filetype": "pfb"}
     resp = client.post('/namespace/name/imports', json=payload, headers=good_headers)
-    assert resp.status_code == 403
+    assert resp.status_code == 400
 
 @pytest.mark.parametrize("manifest,workspace_cloud_platform",[
     ("test_tdr_response_gcp.json", "azure"),
@@ -245,5 +245,5 @@ def test_blocks_cross_platform_tdr_imports(monkeypatch, client, manifest, worksp
     monkeypatch.setattr("app.new_import.http.http_as_filelike", mock.MagicMock(return_value=open(f"app/tests/resources/{manifest}", "rb")))
 
     resp = client.post('/mynamespace/myname/imports', json=good_tdr_json, headers=good_headers)
-    assert resp.status_code == 403
-    assert resp.text == "Unable to import TDR data across cloud platforms"
+    assert resp.status_code == 400
+    assert resp.text == "Import Not Allowed - Unable to import TDR data across cloud platforms"

--- a/app/util/exceptions.py
+++ b/app/util/exceptions.py
@@ -69,6 +69,11 @@ class InvalidFiletypeException(ISvcException):
         audit_logs = [AuditLog(f"User {user_info.subject_id} {user_info.user_email} attempted to import from filetype {import_filetype}", logging.ERROR)]
         super().__init__(f"Path Not Allowed - {hint}: {import_filetype}", 400, audit_logs=audit_logs)
 
+class ForbiddenImportException(ISvcException):
+    def __init__(self, import_url: str, user_info: UserInfo, hint: str):
+        audit_logs = [AuditLog(f"User {user_info.subject_id} {user_info.user_email} attempted to import from path {import_url}", logging.ERROR)]
+        super().__init__(f"Import Not Allowed - {hint}", 400, audit_logs=audit_logs)
+
 class FileTranslationException(ISvcException):
     def __init__(self, imprt: Import, exc: Exception):
         eid = uuid.uuid4()


### PR DESCRIPTION
Currently, when an import is blocked because of attempting to import protected data into an unprotected workspace or when attempting to import from TDR across cloud platforms, import service throws an AuthorizationException and returns a 403 status.

This updates those cases to behave more like validation errors. They now throw a ForbiddenImportException and return 400. Also, they create "audit logs" like validation errors do.