### PR TITLE
DDO-3178 Mitigate Recurring Import Service Deploy Issues by Switching to Dockerhub Mirror of gcloud sdk Image

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -58,7 +58,7 @@ docker run -v $PWD:/app \
   -e ENVIRONMENT=${ENVIRONMENT} \
    $DSDE_TOOLBOX_DOCKER_IMG render-templates.sh
 
-# DDO-3178 - due to issues with legacy jenkins nodes effectin the ability to auth to gcr.io registries, 
+# DDO-3178 - due to issues with legacy jenkins nodes effecting the ability to auth to gcr.io registries, 
 # switching to the dockerhub mirror of the gcloud sdk image. These are the same images, just hosted on dockerhub.
 export CLOUD_SDK_DOCKER_IMG=google/cloud-sdk:403.0.0
 docker pull $CLOUD_SDK_DOCKER_IMG

--- a/deploy.sh
+++ b/deploy.sh
@@ -58,7 +58,9 @@ docker run -v $PWD:/app \
   -e ENVIRONMENT=${ENVIRONMENT} \
    $DSDE_TOOLBOX_DOCKER_IMG render-templates.sh
 
-export CLOUD_SDK_DOCKER_IMG=gcr.io/google.com/cloudsdktool/cloud-sdk:403.0.0
+# DDO-3178 - due to issues with legacy jenkins nodes effectin the ability to auth to gcr.io registries, 
+# switching to the dockerhub mirror of the gcloud sdk image. These are the same images, just hosted on dockerhub.
+export CLOUD_SDK_DOCKER_IMG=google/cloud-sdk:403.0.0
 docker pull $CLOUD_SDK_DOCKER_IMG
 
 


### PR DESCRIPTION
I think I've found the quickest possible solution to this that stops making life miserable when deploying import service without re doing the deploy process from scratch. From there we can work towards a solution that is more aligned with the rest of the tech stack if the team so desires.

The solution being to just switch to the docker.io registry mirror of the gcloud sdk docker image. It is the exact same image, just mirrored onto docker hub instead of gcr, and I've already verifed that the SHAs match and that the dockerhub mirror is not vulnerable to what ever weirdness is happening with the docker auths config on jenkins nodes.

I assume we'll want to test this by deploying import service to dev off this branch or something, but I'm honestly not sure how to do that.