### PR TITLE
[AJ-1356] Update import sources configuration

### DIFF
--- a/app.yaml.ctmpl
+++ b/app.yaml.ctmpl
@@ -66,7 +66,7 @@ env_variables:
  RAWLS_PUBSUB_PROJECT: "broad-dsde-{{$env}}"
  RAWLS_PUBSUB_TOPIC: "rawls-async-import-topic-{{$env}}"
 
- IMPORT_ALLOWED_NETLOCS: "{{if eq $env "prod"}}service.prod.anvil.gi.ucsc.edu{{else}}service.anvil.gi.ucsc.edu{{end}},*dev.singlecell.gi.ucsc.edu,*gen3.biodatacatalyst.nhlbi.nih.gov,*service.azul.data.humancellatlas.org"
+ IMPORT_ALLOWED_NETLOCS: "{{if eq $env "prod"}}service.prod.anvil.gi.ucsc.edu{{else}}service.anvil.gi.ucsc.edu{{end}},*.singlecell.gi.ucsc.edu,*gen3.biodatacatalyst.nhlbi.nih.gov,*service.azul.data.humancellatlas.org"
  IMPORT_RESTRICTED_SOURCES: "{{if eq $env "prod"}}{{else}}s3://edu-ucsc-gi-platform-anvil-prod-storage-anvilprod.us-east-1,s3://edu-ucsc-gi-platform-hca-prod-storage-prod.us-east-1{{end}}"
 
 {{end}}{{end}}{{end}}{{end}}{{end}}{{end}}{{end}}{{end}}{{end}}

--- a/app.yaml.ctmpl
+++ b/app.yaml.ctmpl
@@ -66,8 +66,8 @@ env_variables:
  RAWLS_PUBSUB_PROJECT: "broad-dsde-{{$env}}"
  RAWLS_PUBSUB_TOPIC: "rawls-async-import-topic-{{$env}}"
 
- IMPORT_ALLOWED_NETLOCS: "{{if eq $env "prod"}}service.prod.anvil.gi.ucsc.edu{{else}}service.anvil.gi.ucsc.edu{{end}},*.singlecell.gi.ucsc.edu,*gen3.biodatacatalyst.nhlbi.nih.gov,*service.azul.data.humancellatlas.org"
- IMPORT_RESTRICTED_SOURCES: "{{if eq $env "prod"}}{{else}}s3://edu-ucsc-gi-platform-anvil-prod-storage-anvilprod.us-east-1,s3://edu-ucsc-gi-platform-hca-prod-storage-prod.us-east-1{{end}}"
+ IMPORT_ALLOWED_NETLOCS: "{{if eq $env "prod"}}service.prod.anvil.gi.ucsc.edu{{else}}anvil.gi.ucsc.edu{{end}},*.singlecell.gi.ucsc.edu,*gen3.biodatacatalyst.nhlbi.nih.gov,*service.azul.data.humancellatlas.org"
+ IMPORT_RESTRICTED_SOURCES: "{{if eq $env "prod"}}{{else}}prod.anvil.gi.ucsc.edu,s3://edu-ucsc-gi-platform-anvil-prod-storage-anvilprod.us-east-1,s3://edu-ucsc-gi-platform-hca-prod-storage-prod.us-east-1{{end}}"
 
 {{end}}{{end}}{{end}}{{end}}{{end}}{{end}}{{end}}{{end}}{{end}}
 

--- a/app.yaml.ctmpl
+++ b/app.yaml.ctmpl
@@ -67,7 +67,7 @@ env_variables:
  RAWLS_PUBSUB_TOPIC: "rawls-async-import-topic-{{$env}}"
 
  IMPORT_ALLOWED_NETLOCS: "{{if eq $env "prod"}}service.prod.anvil.gi.ucsc.edu{{else}}service.anvil.gi.ucsc.edu{{end}},*dev.singlecell.gi.ucsc.edu,*gen3.biodatacatalyst.nhlbi.nih.gov,*service.azul.data.humancellatlas.org"
- IMPORT_RESTRICTED_SOURCES: "{{if eq $env "prod"}}{{else}}s3://edu-ucsc-gi-platform-anvil-prod-storage-anvilprod.us-east-1{{end}}"
+ IMPORT_RESTRICTED_SOURCES: "{{if eq $env "prod"}}{{else}}s3://edu-ucsc-gi-platform-anvil-prod-storage-anvilprod.us-east-1,s3://edu-ucsc-gi-platform-hca-prod-storage-prod.us-east-1{{end}}"
 
 {{end}}{{end}}{{end}}{{end}}{{end}}{{end}}{{end}}{{end}}{{end}}
 

--- a/app/protected_data.py
+++ b/app/protected_data.py
@@ -51,6 +51,10 @@ def get_restricted_url_patterns() -> List[re.Pattern]:
         if source.startswith("s3://"):
             bucket_name = source[5:]
             restricted_url_patterns.extend(url_patterns_for_s3_bucket(bucket_name))
+        else:
+            hostname = source
+            restricted_url_patterns.append(url_pattern_for_host(hostname))
+
 
     return restricted_url_patterns
 

--- a/app/tests/test_protected_data.py
+++ b/app/tests/test_protected_data.py
@@ -5,17 +5,23 @@ import pytest
 
 from app import protected_data
 
-@mock.patch.dict(os.environ, {"IMPORT_RESTRICTED_SOURCES": "s3://test-bucket-1,s3://test-bucket-2"})
+@mock.patch.dict(os.environ, {"IMPORT_RESTRICTED_SOURCES": "s3://test-bucket-1,s3://test-bucket-2,test.example.com"})
 def test_get_restricted_url_patterns():
   assert protected_data.get_restricted_url_patterns() == [
     *protected_data.url_patterns_for_s3_bucket("test-bucket-1"),
     *protected_data.url_patterns_for_s3_bucket("test-bucket-2"),
+    protected_data.url_pattern_for_host("test.example.com"),
   ]
 
-@mock.patch.object(protected_data, "RESTRICTED_URL_PATTERNS", protected_data.url_patterns_for_s3_bucket("restricted-bucket"))
+@mock.patch.object(protected_data, "RESTRICTED_URL_PATTERNS", [
+  *protected_data.url_patterns_for_s3_bucket("restricted-bucket"),
+  protected_data.url_pattern_for_host("test.example.com"),
+])
 @pytest.mark.parametrize("import_url,expected_is_restricted", [
   ("https://s3.amazonaws.com/restricted-bucket/path/to/file.pfb", True),
   ("https://s3.amazonaws.com/other-bucket/path/to/file.pfb", False),
+  ("https://test.example.com/path/to/file.pfb", True),
+  ("https://example.com/path/to/file.pfb", False),
 ])
 def test_is_restricted_import(import_url, expected_is_restricted):
   assert protected_data.is_restricted_import(import_url) == expected_is_restricted


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1356

UCSC requested we make the following changes:

> Could the Terra team please allow imports into Terra dev (bvdp-saturn-dev.appspot.com from URLs with a scheme of https and either
> 
> - a netloc that is s3.amazonaws.com and a path that starts with edu-ucsc-gi-platform- and that is neither edu-ucsc-gi-platform-hca-prod-storage-prod.us-east-1 nor edu-ucsc-gi-platform-anvil-prod-storage-anvilprod.us-east-1
> - a netloc that ends in .singlecell.gi.ucsc.edu
>
> - or a netloc that ends in .anvil.gi.ucsc.edu and that is not service.prod.anvil.gi.ucsc.edu

To satisfy this request, this PR does the following...

- Adds `s3://edu-ucsc-gi-platform-hca-prod-storage-prod.us-east-1` to the list of restricted sources for non-production Terra.
- Update allowed import sources configuration and replaces `*dev.singlecell.gi.ucsc.edu` with `*.singlecell.gi.ucsc.edu`.
- Updates allowed import sources for non-production from `service.anvil.gi.ucsc.edu` to `anvil.gi.ucsc.edu`. To prevent that change from allowing importing production data into non-production Terra, it also adds `prod.anvil.gi.ucsc.edu` to the restricted sources for non-production environments. This required updating the restricted sources code to allow specifying HTTPS sources.