### PR TITLE
[AJ-1399] Add --no-cache flag to gcloud app deploy

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -74,4 +74,4 @@ docker run -v $PWD:/app \
   -w /app \
   --entrypoint "/bin/bash" \
    $CLOUD_SDK_DOCKER_IMG \
-  -c "ls app && gcloud auth activate-service-account --key-file=deployer.json --project=$GOOGLE_PROJECT && gcloud app deploy app.yaml cron.yaml --project=$GOOGLE_PROJECT"
+  -c "ls app && gcloud auth activate-service-account --key-file=deployer.json --project=$GOOGLE_PROJECT && gcloud app deploy app.yaml cron.yaml --project=$GOOGLE_PROJECT --no-cache"


### PR DESCRIPTION
Since we put a lifecycle rule on the artifacts bucket that deletes objects after 7 days, older images in the Container Registry may be broken since their underlying storage objects may have been deleted.

This attempts to work around that by telling the App Engine deploy step not to use a cache.