### PR TITLE
[AJ-1464] Add dev AnVIL bucket to protected data sources

### DIFF
--- a/app/protected_data.py
+++ b/app/protected_data.py
@@ -27,6 +27,7 @@ PROTECTED_URL_PATTERNS: List[re.Pattern] = [
     *url_patterns_for_s3_bucket("edu-ucsc-gi-platform-anvil-prod-storage-anvilprod.us-east-1"),
     # AnVIL development
     url_pattern_for_host("service.anvil.gi.ucsc.edu"),
+    *url_patterns_for_s3_bucket("edu-ucsc-gi-platform-anvil-dev-storage-anvildev.us-east-1"),
     # BioData Catalyst
     url_pattern_for_host("gen3.biodatacatalyst.nhlbi.nih.gov"),
     *url_patterns_for_s3_bucket("gen3-biodatacatalyst-nhlbi-nih-gov-pfb-export"),


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1464

This adds the dev AnVIL bucket to the list of protected data sources. Making development match production as much as possible helps with testing importing AnVIL data.